### PR TITLE
fix: fn_endpoint request Connection Failed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2819,9 +2819,9 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "ureq"
-version = "0.12.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd754afd5f60388b4188210c3795392c5f2fd69a1cc947ec4505dbfee955b902"
+checksum = "677df6896edc382f1a2abcbb3e4058edfe973cdc4e1ed764b11891a7a289bfc0"
 dependencies = [
  "base64 0.12.2",
  "chunked_transfer",
@@ -2829,6 +2829,7 @@ dependencies = [
  "lazy_static",
  "qstring",
  "rustls 0.17.0",
+ "serde",
  "serde_json",
  "url 2.1.1",
  "webpki",

--- a/csml_interpreter/Cargo.toml
+++ b/csml_interpreter/Cargo.toml
@@ -32,7 +32,7 @@ serde_json = "1.0"
 libc = "0.2.68"
 lazy_static = "1.4.0"
 regex = "1.3.6"
-ureq = { version = "0.12.1", features = ["json"] }
+ureq = { version = "1.3.0", features = ["json"] }
 
 [[example]]
 name = "hello_world"

--- a/csml_interpreter/src/interpreter/builtins/http.rs
+++ b/csml_interpreter/src/interpreter/builtins/http.rs
@@ -3,6 +3,7 @@ use crate::data::position::Position;
 use crate::data::{ast::Interval, Literal};
 use crate::error_format::*;
 use std::collections::HashMap;
+use std::env;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// PRIVATE FUNCTIONS
@@ -90,7 +91,18 @@ pub fn http_request(
 
     match body {
         Ok(value) => Ok(value),
-        Err(_) => Ok(serde_json::Value::Null),
+        Err(err) => {
+            if let Ok(var) = env::var("DEBUG") {
+                if var == "true" {
+                    println!(
+                        "FN request failed: {:?}",
+                        err
+                    );
+                }
+            }
+
+            Ok(serde_json::Value::Null)
+        },
         // Err(gen_error_info(
         //     interval,
         //     format!("{}: {}", status, ERROR_FAIL_RESPONSE_JSON),


### PR DESCRIPTION
Old ureq library has sometimes issues with calling the set fn_endpoint. Updating to latest ureq version seems to fix the problem.