### PR TITLE
chore: rename library and bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,23 +373,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "697c714f50560202b1f4e2e09cd50a421881c83e9025db75d15f276616f04f40"
 
 [[package]]
-name = "csmlinterpreter"
-version = "1.0.0"
-dependencies = [
- "lazy_static",
- "libc",
- "nom",
- "nom_locate",
- "rand 0.7.3",
- "regex",
- "serde",
- "serde_json",
- "ureq",
-]
-
-[[package]]
-name = "csmlrustmanager"
-version = "1.0.0"
+name = "csml_manager"
+version = "1.1.0"
 dependencies = [
  "base64 0.12.3",
  "bson",
@@ -405,6 +390,33 @@ dependencies = [
  "serde",
  "serde_json",
  "uuid 0.8.1",
+]
+
+[[package]]
+name = "csml_manager_node"
+version = "1.1.0"
+dependencies = [
+ "csml_manager",
+ "neon",
+ "neon-build",
+ "neon-serde",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "csmlinterpreter"
+version = "1.1.0"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "nom",
+ "nom_locate",
+ "rand 0.7.3",
+ "regex",
+ "serde",
+ "serde_json",
+ "ureq",
 ]
 
 [[package]]
@@ -1076,18 +1088,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 dependencies = [
  "linked-hash-map",
-]
-
-[[package]]
-name = "manager"
-version = "0.1.0"
-dependencies = [
- "csmlrustmanager",
- "neon",
- "neon-build",
- "neon-serde",
- "serde",
- "serde_json",
 ]
 
 [[package]]

--- a/bindings/node/native/Cargo.toml
+++ b/bindings/node/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "manager"
-version = "0.1.0"
+name = "csml_manager_node"
+version = "1.1.0"
 authors = ["Alexis Merelo <alexis.merelo@clevy.io>"]
 license = "MIT"
 build = "build.rs"
@@ -8,7 +8,7 @@ exclude = ["artifacts.json", "index.node"]
 edition = "2018"
 
 [lib]
-name = "manager"
+name = "csml_manager_node"
 crate-type = ["cdylib"]
 
 [build-dependencies]
@@ -17,6 +17,6 @@ neon-build = "0.4.0"
 [dependencies]
 neon = "0.4.0"
 neon-serde = "0.4.0"
-csmlrustmanager = { path = "../../../csml_manager", features = ["http", "mongo"]}
+csml_manager = { path = "../../../csml_manager", features = ["http", "mongo"]}
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/bindings/node/native/src/lib.rs
+++ b/bindings/node/native/src/lib.rs
@@ -1,4 +1,4 @@
-use csmlrustmanager::{
+use csml_manager::{
     data::CsmlData, start_conversation, user_close_all_conversations, Client, CsmlResult,
     ErrorInfo, Warnings,
 };
@@ -10,7 +10,7 @@ fn get_open_conversation(mut cx: FunctionContext) -> JsResult<JsValue> {
     let jsonclient: Value = neon_serde::from_value(&mut cx, jsclient)?;
     let client: Client = serde_json::from_value(jsonclient).unwrap();
 
-    match csmlrustmanager::get_open_conversation(&client) {
+    match csml_manager::get_open_conversation(&client) {
         Ok(Some(conversation)) => {
             let mut map = serde_json::Map::new();
 
@@ -67,7 +67,7 @@ fn get_bot_steps(mut cx: FunctionContext) -> JsResult<JsObject> {
     let jsbot = cx.argument::<JsValue>(0)?;
     let jsonbot: Value = neon_serde::from_value(&mut cx, jsbot)?;
 
-    let map = csmlrustmanager::get_steps_from_flow(serde_json::from_value(jsonbot).unwrap());
+    let map = csml_manager::get_steps_from_flow(serde_json::from_value(jsonbot).unwrap());
 
     let js_object = JsObject::new(&mut cx);
 
@@ -138,7 +138,7 @@ fn validate_bot(mut cx: FunctionContext) -> JsResult<JsObject> {
 
     let object = JsObject::new(&mut cx);
 
-    match csmlrustmanager::validate_bot(serde_json::from_value(jsonbot).unwrap()) {
+    match csml_manager::validate_bot(serde_json::from_value(jsonbot).unwrap()) {
         CsmlResult {
             flows: _,
             warnings,

--- a/csml_interpreter/Cargo.toml
+++ b/csml_interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "csmlinterpreter"
-version = "1.0.0"
+version = "1.1.0"
 authors = [
     "Alexis Merelo <alexis.merelo@clevy.io>",
     "Jefferson Le Quellec <jefferson.le-quellec@clevy.io>",

--- a/csml_manager/Cargo.toml
+++ b/csml_manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "csmlrustmanager"
-version = "1.0.0"
+name = "csml_manager"
+version = "1.1.0"
 authors = ["Alexis Merelo <alexis.merelo@clevy.io>"]
 license = "Apache-2.0"
 edition = "2018"

--- a/csml_manager/examples/command_line.rs
+++ b/csml_manager/examples/command_line.rs
@@ -2,7 +2,7 @@ use csmlinterpreter::{
     data::{csml_bot::CsmlBot, csml_flow::CsmlFlow, Client},
     load_components,
 };
-use csmlrustmanager::{data::*, start_conversation};
+use csml_manager::{data::*, start_conversation};
 use serde_json::{json, Value};
 use std::fs::File;
 use std::io::prelude::*;


### PR DESCRIPTION
Library and folder names don't match!

## Proposed Changes

- Rename library to match folder name convention
- Bump libs to 1.1.0
