### PR TITLE
feat: add conversations open/close endpoints

### DIFF
--- a/csml_server/src/main.rs
+++ b/csml_server/src/main.rs
@@ -50,6 +50,14 @@ async fn main() -> std::io::Result<()> {
         web::resource("/run")
           .route(web::post().to(routes::run::handler))
       )
+      .service(
+        web::resource("/conversations/open")
+          .route(web::post().to(routes::conversations::get_open))
+      )
+      .service(
+        web::resource("/conversations/close")
+          .route(web::post().to(routes::conversations::close_user_conversations))
+      )
 
   })
   .bind(format!("0.0.0.0:{}", server_port))?

--- a/csml_server/src/routes/conversations.rs
+++ b/csml_server/src/routes/conversations.rs
@@ -1,0 +1,27 @@
+use actix_web::{web, HttpResponse};
+use csml_manager::{user_close_all_conversations, get_open_conversation, Client};
+
+pub async fn get_open(body: web::Json<Client>) -> HttpResponse {
+
+  match get_open_conversation(&body) {
+    Ok(Some(conversation)) => HttpResponse::Ok().json(conversation),
+    Ok(None) => HttpResponse::Ok().finish(),
+    Err(err) => {
+      eprintln!("ManagerError: {:?}", err);
+      HttpResponse::InternalServerError().finish()
+    }
+  }
+
+}
+
+pub async fn close_user_conversations(body: web::Json<Client>) -> HttpResponse {
+
+  match user_close_all_conversations(body.clone()) {
+    Ok(()) => HttpResponse::Ok().finish(),
+    Err(err) => {
+      eprintln!("ManagerError: {:?}", err);
+      HttpResponse::InternalServerError().finish()
+    }
+  }
+
+}

--- a/csml_server/src/routes/mod.rs
+++ b/csml_server/src/routes/mod.rs
@@ -1,3 +1,4 @@
 pub mod index;
 pub mod validate;
 pub mod run;
+pub mod conversations;

--- a/csml_server/static/index.html
+++ b/csml_server/static/index.html
@@ -122,6 +122,26 @@ DEBUG=true</code></pre>
   "name": "mybot",
   "fn_endpoint": ""
 }'</code></pre>
+
+
+    <p class="text-lg font-base mb-2">Get a user's latest open conversation:</p>
+    <pre class="bg-gray-800 py-3 px-4 rounded-lg"><code class="text-sm text-white">curl -X "POST" "http://localhost:5000/conversations/open" \
+  -H 'content-type: application/json' \
+  -d $'{
+    "user_id": "some-user-id",
+    "channel_id": "some-channel",
+    "bot_id": "some-bot-id"
+  }'</code></pre>
+
+    <p class="text-lg font-base mb-2">Close all conversations for a given user:</p>
+    <pre class="bg-gray-800 py-3 px-4 rounded-lg"><code class="text-sm text-white">curl -X "POST" "http://localhost:5000/conversations/close" \
+-H 'content-type: application/json' \
+-d $'{
+  "user_id": "some-user-id",
+  "channel_id": "some-channel",
+  "bot_id": "some-bot-id"
+}'</code></pre>
+
   </section>
 </body>
 


### PR DESCRIPTION
Add 2 endpoints on CSML server:

- `POST /conversations/open`: retrieve the latest open conversation for a given client
- `POST /conversations/close`: close any remaining open conversation for a given client

Both requests take a full CSML engine Client as body:
```json
{
  "user_id": "some-user-id",
  "channel_id": "some-channel-id",
  "bot_id": "some-bot-id"
}
```