### PR TITLE
chore: rename Event fields for clarity

### DIFF
--- a/csml_interpreter/CSML/basic_test/event.csml
+++ b/csml_interpreter/CSML/basic_test/event.csml
@@ -15,7 +15,7 @@ step_2:
     goto end
 
 step_3:
-    say event.get_metadata()
+    say event.get_content()
     goto end
 
 step_4:

--- a/csml_interpreter/examples/hello_world.rs
+++ b/csml_interpreter/examples/hello_world.rs
@@ -35,8 +35,8 @@ fn main() {
     // Create an Event
     let event = Event {
         content_type: "text".to_owned(),
-        content: "4".to_owned(),
-        metadata: serde_json::json!({"text":"4"}),
+        content_value: "4".to_owned(),
+        content: serde_json::json!({"text":"4"}),
     };
 
     // Create context

--- a/csml_interpreter/src/data/event.rs
+++ b/csml_interpreter/src/data/event.rs
@@ -5,8 +5,8 @@
 #[derive(Debug, Clone)]
 pub struct Event {
     pub content_type: String,
-    pub content: String,
-    pub metadata: serde_json::Value,
+    pub content_value: String,
+    pub content: serde_json::Value,
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -17,8 +17,8 @@ impl Default for Event {
     fn default() -> Self {
         Self {
             content_type: String::default(),
-            content: String::default(),
-            metadata: serde_json::json!({}),
+            content_value: String::default(),
+            content: serde_json::json!({}),
         }
     }
 }
@@ -28,11 +28,11 @@ impl Default for Event {
 ////////////////////////////////////////////////////////////////////////////////
 
 impl Event {
-    pub fn new(content_type: &str, content: &str, metadata: serde_json::Value) -> Self {
+    pub fn new(content_type: &str, content_value: &str, content: serde_json::Value) -> Self {
         Self {
             content_type: content_type.to_owned(),
-            content: content.to_owned(),
-            metadata,
+            content_value: content_value.to_owned(),
+            content,
         }
     }
 }

--- a/csml_interpreter/src/data/primitive/object.rs
+++ b/csml_interpreter/src/data/primitive/object.rs
@@ -75,9 +75,9 @@ lazy_static! {
             (PrimitiveObject::get_type as PrimitiveMethod, Right::Read),
         );
         map.insert(
-            "get_metadata",
+            "get_content",
             (
-                PrimitiveObject::get_metadata as PrimitiveMethod,
+                PrimitiveObject::get_content as PrimitiveMethod,
                 Right::Read,
             ),
         );
@@ -551,13 +551,13 @@ impl PrimitiveObject {
         Ok(PrimitiveString::get_literal(content_type, interval))
     }
 
-    fn get_metadata(
+    fn get_content(
         object: &mut PrimitiveObject,
         args: &HashMap<String, Literal>,
         interval: Interval,
         content_type: &str,
     ) -> Result<Literal, ErrorInfo> {
-        let usage = "get_metadata() => object";
+        let usage = "get_content() => object";
 
         if !args.is_empty() {
             return Err(gen_error_info(

--- a/csml_interpreter/src/interpreter/variable_handler/gen_literal.rs
+++ b/csml_interpreter/src/interpreter/variable_handler/gen_literal.rs
@@ -28,7 +28,7 @@ pub fn gen_literal_from_event(
     match path {
         Some(path) => {
             let path = resolve_path(path, data, root, sender)?;
-            let mut lit = json_to_literal(&data.event.metadata, interval.to_owned())?;
+            let mut lit = json_to_literal(&data.event.content, interval.to_owned())?;
 
             lit.set_content_type("event");
 
@@ -48,7 +48,7 @@ pub fn gen_literal_from_event(
             Ok(lit)
         }
         None => Ok(PrimitiveString::get_literal(
-            &data.event.content,
+            &data.event.content_value,
             interval.to_owned(),
         )),
     }

--- a/csml_manager/src/lib.rs
+++ b/csml_manager/src/lib.rs
@@ -38,8 +38,6 @@ use std::{collections::HashMap, env, time::SystemTime};
  * - bot_id: differentiate bots handled by the same CSML engine instance
  * - channel_id: a given bot may be used on different channels (messenger, slack...)
  * - user_id: differentiate users on the same communication channel
- *
- *
  */
 pub fn start_conversation(
     request: CsmlRequest,

--- a/csml_manager/src/utils.rs
+++ b/csml_manager/src/utils.rs
@@ -85,13 +85,13 @@ pub fn format_event(json_event: serde_json::Value) -> Result<Event, ManagerError
             ))
         }
     };
-    let metadata = json_event["payload"]["content"].to_owned();
+    let content = json_event["payload"]["content"].to_owned();
 
-    let content = get_event_content(&content_type, &metadata)?;
+    let content_value = get_event_content(&content_type, &content)?;
     Ok(Event {
         content_type,
+        content_value,
         content,
-        metadata,
     })
 }
 
@@ -225,12 +225,12 @@ pub fn search_flow<'a>(
     match event {
         event if event.content_type == "flow_trigger" => {
             delete_state_key(&client, "hold", "position", db)?;
-            get_flow_by_id(&event.content, &bot.flows)
+            get_flow_by_id(&event.content_value, &bot.flows)
         }
         event => {
             for flow in bot.flows.iter() {
                 for command in flow.commands.iter() {
-                    if &command.to_lowercase() == &event.content.to_lowercase() {
+                    if &command.to_lowercase() == &event.content_value.to_lowercase() {
                         delete_state_key(&client, "hold", "position", db)?;
                         return Ok(flow);
                     }
@@ -238,7 +238,7 @@ pub fn search_flow<'a>(
             }
             Err(ManagerError::Interpreter(format!(
                 "Flow '{}' does not exist",
-                event.content
+                event.content_value
             )))
         }
     }


### PR DESCRIPTION
Event.metadata is misleading with conversation metadata. Also, in CSML, event.get_metadata() makes absolutely no sense.

Let's rewrite everything like so:

```
event.content => event.content_value
event.metadata => event.content
event.get_metadata() => event.get_content()
```