### PR TITLE
fix: add retrocompatibility for hex-encoded encrypted values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -785,6 +785,7 @@ dependencies = [
  "chrono",
  "csml_interpreter",
  "curl",
+ "hex 0.4.2",
  "http_db",
  "md-5",
  "mongodb",

--- a/csml_manager/Cargo.toml
+++ b/csml_manager/Cargo.toml
@@ -57,6 +57,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 openssl = "0.10.30"
 base64 = "0.12.3"
+hex = "0.4.2"
 curl = { version = "0.4.31", default-features = false, features = ["mesalink"] }
 tokio = "0.2.22"
 


### PR DESCRIPTION
Older data using legacy dynamodb connector used hex encoding for encrypted data, which must remain readable. This adds a fallback to hex when base64 decode does not work.