### PR TITLE
fix: update server build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,12 @@ CSML is built in [Rust](https://www.rust-lang.org/). You don't need to know any 
 
 ```
 cd csml_server
-cargo build --release
+
+# for use with MongoDB
+cargo build --release --features csml_engine/mongo
+
+# for use with Amazon DynamoDB
+cargo build --release --features csml_engine/dynamo
 ```
 
 After that, execute your build (by default under ./targets/release/csml_server) and visit http://localhost:5000 for some request examples.

--- a/csml_server/Cargo.toml
+++ b/csml_server/Cargo.toml
@@ -19,5 +19,5 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 json = "0.12"
 
-csml_engine = { path = "../csml_engine", features = ["mongo", "dynamo"]}
+csml_engine = { path = "../csml_engine"}
 csml_interpreter = { path = "../csml_interpreter" }


### PR DESCRIPTION
When building CSML server, there is no need to build the nodejs bindings as well. Let's just build the CSML server package!