### PR TITLE
feat: use vendored openssl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1886,6 +1886,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
+name = "openssl-src"
+version = "111.10.2+1.1.1g"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a287fdb22e32b5b60624d4a5a7a02dbe82777f730ec0dbc42a0554326fef5a70"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1894,6 +1903,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/csml_engine/Cargo.toml
+++ b/csml_engine/Cargo.toml
@@ -44,7 +44,7 @@ chrono = "0.4"
 uuid = { version = "0.8.1", features = ["serde", "v4"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-openssl = "0.10.30"
+openssl = { version = "0.10.30", features = ["vendored"] }
 base64 = "0.12.3"
 hex = "0.4.2"
 curl = { version = "0.4.31", default-features = false, features = ["mesalink"] }


### PR DESCRIPTION
Using dynamically-linked openssl prevents us to easily distribute prebuilt binaries (as it requires every user to have openssl or libssl preinstalled on their machine, which might be a complex requirement for most beginner users).
Using vendored openssl makes this so much easier!