### PR TITLE
feat: read the component name from the file name

### DIFF
--- a/csml_interpreter/src/interpreter/components.rs
+++ b/csml_interpreter/src/interpreter/components.rs
@@ -12,37 +12,43 @@ pub mod video;
 pub mod wait;
 
 use crate::data::error_info::ErrorInfo;
-use std::io::prelude::*;
 use std::{env, fs};
+use std::io::prelude::*;
+use std::path::Path;
 
 ////////////////////////////////////////////////////////////////////////////////
 // PRIVATE FUNCTION
 ////////////////////////////////////////////////////////////////////////////////
 
 fn read_components_dir(
+    dir: &Path,
     map: &mut serde_json::Map<String, serde_json::Value>,
 ) -> Result<(), ErrorInfo> {
-    // load components from the `COMPONENTS_DIR` dir if any
-    let components_dir = match env::var("COMPONENTS_DIR") {
-        Ok(components_dir) => components_dir,
-        Err(_) => return Ok(()),
-    };
 
-    let paths = fs::read_dir(components_dir)?;
+    if dir.is_dir() {
+        for entry in fs::read_dir(dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if !path.is_dir() {
+                let mut file = fs::File::open(path.to_str().unwrap())?;
+                let mut contents = String::new();
+                file.read_to_string(&mut contents)?;
 
-    for path in paths {
-        let mut file = fs::File::open(path?.path().to_str().unwrap())?;
-        let mut contents = String::new();
-        file.read_to_string(&mut contents)?;
+                let component: serde_json::Value = serde_json::from_str(&contents).unwrap();
 
-        let component: serde_json::Value = serde_json::from_str(&contents)?;
-
-        if let serde_json::Value::Object(mut obj) = component {
-            map.append(&mut obj);
-        } else {
-            // TODO: error msg
-            eprintln!("native component bad format {:?}", component);
+                if let serde_json::Value::Object(obj) = component {
+                    let file_stem = path.file_stem().unwrap();
+                    let component_name: &str = file_stem.to_str().unwrap();
+                    map.insert(component_name.to_owned(), serde_json::json!(obj));
+                } else {
+                    // TODO: error msg
+                    eprintln!("Invalid custom component formatting {:?}", component);
+                }
+            }
         }
+    }
+    else {
+        eprintln!("{} is not a directory!", dir.to_str().unwrap());
     }
 
     Ok(())
@@ -68,7 +74,14 @@ pub fn load_components() -> Result<serde_json::Map<String, serde_json::Value>, E
     video::add_video(&mut map);
     wait::add_wait(&mut map);
 
-    let _res = read_components_dir(&mut map)?;
+    // load components from the `COMPONENTS_DIR` dir if any
+    let components_dir = match env::var("COMPONENTS_DIR") {
+        Ok(dir) => dir,
+        Err(_) => return Ok(map),
+    };
+
+    let components_dir = Path::new(&components_dir);
+    let _res = read_components_dir(&components_dir, &mut map)?;
 
     Ok(map)
 }


### PR DESCRIPTION
Improve experience of creating custom components by loading the names from the file name instead of having to wrap them