### PR TITLE
add break to parse fn root functions

### DIFF
--- a/csml_interpreter/src/parser/parse_actions.rs
+++ b/csml_interpreter/src/parser/parse_actions.rs
@@ -342,6 +342,7 @@ where
         parse_do,
         parse_if,
         parse_foreach,
+        parse_break,
         parse_return,
         catch_scope_fn_common_mistakes,
     ))(s)


### PR DESCRIPTION
Fixes #173 

## Proposed Changes

- add break to the allowed commands of a function
