### PR TITLE
fix: github bumped ubuntu latest to 20.04, sticking to 18.04 for now

### DIFF
--- a/.github/workflows/aws_lambda.yml
+++ b/.github/workflows/aws_lambda.yml
@@ -11,9 +11,9 @@ jobs:
       MACOSX_DEPLOYMENT_TARGET: 10.11
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-18.04]
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-18.04
             asset_name: csml-server-lambda
 
     steps:
@@ -21,7 +21,7 @@ jobs:
 
     # for some reason cache does not work properly with macos builds
     - name: Cache Cargo
-      if: matrix.os != 'macos-latest'
+      if: matrix.os != 'macos-10.15'
       uses: actions/cache@v2
       with:
         path: |

--- a/.github/workflows/cratesio.yml
+++ b/.github/workflows/cratesio.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   publish:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -11,11 +11,11 @@ jobs:
       MACOSX_DEPLOYMENT_TARGET: 10.11
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-18.04, macos-10.15]
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-18.04
             asset_name: csml-server-linux-amd64
-          - os: macos-latest
+          - os: macos-10.15
             asset_name: csml-server-macos-amd64
 
     steps:
@@ -23,7 +23,7 @@ jobs:
 
     # for some reason cache does not work properly with macos builds
     - name: Cache Cargo
-      if: matrix.os != 'macos-latest'
+      if: matrix.os != 'macos-10.15'
       uses: actions/cache@v2
       with:
         path: |
@@ -59,11 +59,11 @@ jobs:
       MACOSX_DEPLOYMENT_TARGET: 10.11
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-18.04, macos-10.15]
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-18.04
             asset_name: csml-server-linux-amd64
-          - os: macos-latest
+          - os: macos-10.15
             asset_name: csml-server-macos-amd64
 
     steps:
@@ -85,7 +85,7 @@ jobs:
 
 
   publish-docker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     needs: build
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,14 +14,14 @@ jobs:
       MACOSX_DEPLOYMENT_TARGET: 10.11
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-18.04, macos-10.15]
 
     steps:
     - uses: actions/checkout@v2
 
     # for some reason cache does not work properly with macos builds
     - name: Cache Cargo
-      if: matrix.os != 'macos-latest'
+      if: matrix.os != 'macos-10.15'
       uses: actions/cache@v2
       with:
         path: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -838,7 +838,7 @@ checksum = "697c714f50560202b1f4e2e09cd50a421881c83e9025db75d15f276616f04f40"
 
 [[package]]
 name = "csml_engine"
-version = "1.4.0-beta.4"
+version = "1.4.0-beta.5"
 dependencies = [
  "base64 0.13.0",
  "bincode",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "csml_engine_node"
-version = "1.4.0-beta.4"
+version = "1.4.0-beta.5"
 dependencies = [
  "csml_engine",
  "csml_interpreter",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csml_interpreter"
-version = "1.4.0-beta.4"
+version = "1.4.0-beta.5"
 dependencies = [
  "base64 0.13.0",
  "bincode",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csml_server"
-version = "1.4.0-beta.4"
+version = "1.4.0-beta.5"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:19.04
 
 WORKDIR /usr/src/csml
 

--- a/bindings/node/native/Cargo.toml
+++ b/bindings/node/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "csml_engine_node"
-version = "1.4.0-beta.4"
+version = "1.4.0-beta.5"
 authors = ["Alexis Merelo <alexis.merelo@clevy.io>"]
 license = "MIT"
 build = "build.rs"
@@ -17,7 +17,7 @@ neon-build = "0.4.0"
 [dependencies]
 neon = "0.4.0"
 neon-serde = "0.4.0"
-csml_engine = { version = "1.4.0-beta.4", path = "../../../csml_engine", features = ["mongo", "dynamo"]}
-csml_interpreter = { version = "1.4.0-beta.4", path = "../../../csml_interpreter"}
+csml_engine = { version = "1.4.0-beta.5", path = "../../../csml_engine", features = ["mongo", "dynamo"]}
+csml_interpreter = { version = "1.4.0-beta.5", path = "../../../csml_interpreter"}
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/csml_engine/Cargo.toml
+++ b/csml_engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "csml_engine"
-version = "1.4.0-beta.4"
+version = "1.4.0-beta.5"
 authors = [
     "Alexis Merelo <alexis.merelo@clevy.io>",
     "François Falala-Sechet <francois@clevy.io>",
@@ -50,7 +50,7 @@ features = ["rustls"]
 optional = true
 
 [dependencies]
-csml_interpreter = { version = "1.4.0-beta.4", path = "../csml_interpreter" }
+csml_interpreter = { version = "1.4.0-beta.5", path = "../csml_interpreter" }
 multimap = "0.8.2"
 md-5 = "0.9.1"
 chrono = "0.4"

--- a/csml_interpreter/Cargo.toml
+++ b/csml_interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "csml_interpreter"
-version = "1.4.0-beta.4"
+version = "1.4.0-beta.5"
 authors = [
     "Alexis Merelo <alexis.merelo@clevy.io>",
     "François Falala-Sechet <francois@clevy.io>",

--- a/csml_server/Cargo.toml
+++ b/csml_server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "csml_server"
-version = "1.4.0-beta.4"
+version = "1.4.0-beta.5"
 authors = ["François Falala-Sechet <francois@clevy.io>"]
 edition = "2018"
 


### PR DESCRIPTION
Internal upgrade on github actions infrastructure broke the actions workflows for CSML Engine Docker (ubuntu 20.04 has glibc 2.29, 18.04 has 2.27). This pins the version to 18.04 for now.