### PR TITLE
imp: save bots on S3 to save on dynamodb write capacity units

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,8 @@ AWS_ACCESS_KEY_ID=foo
 AWS_SECRET_ACCESS_KEY=bar
 AWS_DYNAMODB_ENDPOINT=http://localhost:8000
 AWS_DYNAMODB_TABLE=csml-engine-db-local
+AWS_S3_ENDPOINT=http://localhost:8000
+AWS_S3_BUCKET=csml-engine-bucket-local
 
 ENGINE_SERVER_PORT=5000
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,6 +353,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
+name = "ahash"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -374,6 +380,118 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "async-channel"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59740d83946db6a5af71ae25ddf9562c2b176b2ca42cf99a455f09f4a220d6b9"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb877970c7b440ead138f6321a3b5395d6061183af779340b65e20c0fede9146"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "once_cell",
+ "vec-arena",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9586ec52317f36de58453159d48351bc244bc24ced3effc1fce22f3d48664af6"
+dependencies = [
+ "async-channel",
+ "async-executor",
+ "async-io",
+ "async-mutex",
+ "blocking",
+ "futures-lite",
+ "num_cpus",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9315f8f07556761c3e48fec2e6b276004acf426e6dc068b2c2251854d65ee0fd"
+dependencies = [
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "libc",
+ "log",
+ "nb-connect",
+ "once_cell",
+ "parking",
+ "polling",
+ "vec-arena",
+ "waker-fn",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1996609732bde4a9988bc42125f55f2af5f3c36370e27c778d5191a4a1b63bfb"
+dependencies = [
+ "event-listener",
+]
+
+[[package]]
+name = "async-mutex"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
+dependencies = [
+ "event-listener",
+]
+
+[[package]]
+name = "async-std"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9f06685bad74e0570f5213741bea82158279a4103d988e57bfada11ad230341"
+dependencies = [
+ "async-channel",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "crossbeam-utils 0.8.1",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "num_cpus",
+ "once_cell",
+ "pin-project-lite 0.2.4",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-task"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
+
+[[package]]
 name = "async-trait"
 version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -382,6 +500,27 @@ dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
  "syn 1.0.48",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
+
+[[package]]
+name = "attohttpc"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe174d1b67f7b2bafed829c09db039301eb5841f66e43be2cf60b326e7f8e2cc"
+dependencies = [
+ "http 0.2.1",
+ "log",
+ "native-tls",
+ "openssl",
+ "serde",
+ "serde_json",
+ "url",
 ]
 
 [[package]]
@@ -423,6 +562,31 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+]
+
+[[package]]
+name = "aws-creds"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad53a54cb2c99990e96eefacde6f143dc6d471ab70809d26d360292be421d490"
+dependencies = [
+ "attohttpc",
+ "dirs 3.0.1",
+ "rust-ini",
+ "serde",
+ "serde-xml-rs",
+ "serde_derive",
+ "simpl",
+ "url",
+]
+
+[[package]]
+name = "aws-region"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f610af4a396f07592014dc3410f6ad78fab931852a99bb6cfdc1ad04b9329b80"
+dependencies = [
+ "simpl",
 ]
 
 [[package]]
@@ -553,6 +717,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "blocking"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e170dbede1f740736619b776d7251cb1b9095c435c34d8ca9f57fcd2f335e9"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "atomic-waker",
+ "fastrand",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
 name = "brotli-sys"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -647,6 +825,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cache-padded"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
+
+[[package]]
 name = "cc"
 version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -703,6 +887,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
+dependencies = [
+ "cache-padded",
+]
+
+[[package]]
 name = "const_fn"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -753,7 +946,17 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
 dependencies = [
- "core-foundation-sys",
+ "core-foundation-sys 0.7.0",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62"
+dependencies = [
+ "core-foundation-sys 0.8.2",
  "libc",
 ]
 
@@ -762,6 +965,18 @@ name = "core-foundation-sys"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
+
+[[package]]
+name = "cpuid-bool"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
 
 [[package]]
 name = "crc32fast"
@@ -779,7 +994,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
 dependencies = [
  "crossbeam-epoch",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "maybe-uninit",
 ]
 
@@ -791,7 +1006,7 @@ checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 dependencies = [
  "autocfg",
  "cfg-if 0.1.10",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "lazy_static",
  "maybe-uninit",
  "memoffset",
@@ -805,7 +1020,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570"
 dependencies = [
  "cfg-if 0.1.10",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "maybe-uninit",
 ]
 
@@ -821,13 +1036,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
+dependencies = [
+ "autocfg",
+ "cfg-if 1.0.0",
+ "lazy_static",
+]
+
+[[package]]
 name = "crypto-mac"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
 dependencies = [
  "generic-array 0.12.3",
- "subtle",
+ "subtle 1.0.0",
+]
+
+[[package]]
+name = "crypto-mac"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58bcd97a54c7ca5ce2f6eb16f6bede5b0ab5f0055fedc17d2f0b4466e21671ca"
+dependencies = [
+ "generic-array 0.14.4",
+ "subtle 2.4.0",
 ]
 
 [[package]]
@@ -854,6 +1090,7 @@ dependencies = [
  "rand 0.7.3",
  "rusoto_core",
  "rusoto_dynamodb",
+ "rust-s3",
  "serde",
  "serde_dynamodb",
  "serde_json",
@@ -1044,6 +1281,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142995ed02755914747cc6ca76fc7e4583cd18578746716d0508ea6ed558b9ff"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1059,6 +1305,15 @@ name = "discard"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
+
+[[package]]
+name = "dlv-list"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b391911b9a786312a10cb9d2b3d0735adfd5a8113eb3648de26a75e91b0826c"
+dependencies = [
+ "rand 0.7.3",
+]
 
 [[package]]
 name = "dtoa"
@@ -1163,6 +1418,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
+
+[[package]]
 name = "failure"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1189,6 +1450,15 @@ name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+
+[[package]]
+name = "fastrand"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca5faf057445ce5c9d4329e382b2ce7ca38550ef3b73a5348362d5f24e0c7fe3"
+dependencies = [
+ "instant",
+]
 
 [[package]]
 name = "flate2"
@@ -1310,6 +1580,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e1798854a4727ff944a7b12aa999f58ce7aa81db80d2dfaaf2ba06f065ddd2b"
 
 [[package]]
+name = "futures-lite"
+version = "1.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4481d0cd0de1d204a4fa55e7d45f07b1d958abcb06714b3446438e2eff695fb"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite 0.2.4",
+ "waker-fn",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1396,6 +1681,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+]
+
+[[package]]
 name = "ghost"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1411,6 +1707,19 @@ name = "gimli"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
+
+[[package]]
+name = "gloo-timers"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47204a46aaff920a1ea58b11d03dec6f704287d27561724a4631e450654a891f"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
 
 [[package]]
 name = "h2"
@@ -1448,6 +1757,16 @@ dependencies = [
  "tokio-util 0.3.1",
  "tracing",
  "tracing-futures",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96282e96bfcd3da0d3aa9938bedf1e50df3269b6db08b4876d2da0bb1a0841cf"
+dependencies = [
+ "ahash",
+ "autocfg",
 ]
 
 [[package]]
@@ -1492,8 +1811,18 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
 dependencies = [
- "crypto-mac",
+ "crypto-mac 0.7.0",
  "digest 0.8.1",
+]
+
+[[package]]
+name = "hmac"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deae6d9dbb35ec2c502d62b8f7b1c000a0822c3b0794ba36b3149c0a1c840dff"
+dependencies = [
+ "crypto-mac 0.9.1",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -1645,6 +1974,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed"
+dependencies = [
+ "bytes 0.5.6",
+ "hyper 0.13.9",
+ "native-tls",
+ "tokio 0.2.22",
+ "tokio-tls",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1668,7 +2010,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.9.1",
 ]
 
 [[package]]
@@ -1720,8 +2062,14 @@ dependencies = [
  "socket2",
  "widestring",
  "winapi 0.3.9",
- "winreg",
+ "winreg 0.6.2",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
 
 [[package]]
 name = "itoa"
@@ -1752,6 +2100,15 @@ checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 dependencies = [
  "winapi 0.2.8",
  "winapi-build",
+]
+
+[[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -2106,7 +2463,7 @@ dependencies = [
  "derivative",
  "err-derive",
  "hex 0.4.2",
- "hmac",
+ "hmac 0.7.1",
  "lazy_static",
  "md-5 0.8.0",
  "os_info",
@@ -2117,7 +2474,7 @@ dependencies = [
  "serde",
  "serde_with",
  "sha-1",
- "sha2",
+ "sha2 0.8.2",
  "stringprep",
  "time 0.1.44",
  "trust-dns-proto 0.19.5",
@@ -2135,6 +2492,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1255076139a83bb467426e7f8d0134968a8118844faa755985e077cf31850333"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework 2.0.0",
+ "security-framework-sys 2.0.0",
+ "tempfile",
+]
+
+[[package]]
+name = "nb-connect"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8123a81538e457d44b933a02faf885d3fe8408806b23fa700e8f01c6c3a98998"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2377,6 +2762,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-multimap"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e88f947c6799d5eff50e6cf8a2365c17ac4aa8f8f43aceeedc29b616d872a358"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.7.2",
+]
+
+[[package]]
 name = "os_info"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2389,6 +2784,12 @@ dependencies = [
  "serde_derive",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "parking"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "parking_lot"
@@ -2421,7 +2822,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "cloudabi 0.0.3",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.1.57",
  "rustc_version",
  "smallvec 0.6.13",
  "winapi 0.3.9",
@@ -2437,7 +2838,7 @@ dependencies = [
  "cloudabi 0.1.0",
  "instant",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.1.57",
  "smallvec 1.4.2",
  "winapi 0.3.9",
 ]
@@ -2450,11 +2851,11 @@ checksum = "006c038a43a45995a9670da19e67600114740e8511d4333bf97a56e66a7542d9"
 dependencies = [
  "base64 0.9.3",
  "byteorder",
- "crypto-mac",
- "hmac",
+ "crypto-mac 0.7.0",
+ "hmac 0.7.1",
  "rand 0.5.6",
- "sha2",
- "subtle",
+ "sha2 0.8.2",
+ "subtle 1.0.0",
 ]
 
 [[package]]
@@ -2510,6 +2911,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
+
+[[package]]
 name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2520,6 +2927,19 @@ name = "pkg-config"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+
+[[package]]
+name = "polling"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2a7bc6b2a29e632e45451c941832803a18cce6781db04de8a04696cdca8bde4"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "log",
+ "wepoll-sys",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -2652,11 +3072,23 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.15",
  "libc",
- "rand_chacha",
+ "rand_chacha 0.2.2",
  "rand_core 0.5.1",
- "rand_hc",
+ "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.0",
+ "rand_core 0.6.1",
+ "rand_hc 0.3.0",
 ]
 
 [[package]]
@@ -2667,6 +3099,16 @@ checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.1",
 ]
 
 [[package]]
@@ -2690,7 +3132,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
+dependencies = [
+ "getrandom 0.2.2",
 ]
 
 [[package]]
@@ -2703,10 +3154,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_hc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+dependencies = [
+ "rand_core 0.6.1",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ec8ca9416c5ea37062b502703cd7fcb207736bc294f6e0cf367ac6fc234570"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "redox_users"
@@ -2714,8 +3183,8 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
 dependencies = [
- "getrandom",
- "redox_syscall",
+ "getrandom 0.1.15",
+ "redox_syscall 0.1.57",
  "rust-argon2",
 ]
 
@@ -2736,6 +3205,51 @@ name = "regex-syntax"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9eaa17ac5d7b838b7503d118fa16ad88f440498bf9ffe5424e621f93190d61e"
+dependencies = [
+ "base64 0.12.3",
+ "bytes 0.5.6",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "http 0.2.1",
+ "http-body 0.3.1",
+ "hyper 0.13.9",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "mime",
+ "mime_guess",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite 0.1.11",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio 0.2.22",
+ "tokio-tls",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg 0.7.0",
+]
 
 [[package]]
 name = "resolv-conf"
@@ -2772,7 +3286,7 @@ dependencies = [
  "base64 0.12.3",
  "bytes 0.5.6",
  "futures 0.3.7",
- "hmac",
+ "hmac 0.7.1",
  "http 0.2.1",
  "hyper 0.13.9",
  "hyper-rustls",
@@ -2786,7 +3300,7 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.8.2",
  "tokio 0.2.22",
  "xml-rs",
 ]
@@ -2799,7 +3313,7 @@ checksum = "60669ddc1bdbb83ce225593649d36b4c5f6bf9db47cc1ab3e81281abffc853f4"
 dependencies = [
  "async-trait",
  "chrono",
- "dirs",
+ "dirs 2.0.2",
  "futures 0.3.7",
  "hyper 0.13.9",
  "pin-project 0.4.27",
@@ -2835,7 +3349,7 @@ dependencies = [
  "bytes 0.5.6",
  "futures 0.3.7",
  "hex 0.4.2",
- "hmac",
+ "hmac 0.7.1",
  "http 0.2.1",
  "hyper 0.13.9",
  "log",
@@ -2845,7 +3359,7 @@ dependencies = [
  "rusoto_credential",
  "rustc_version",
  "serde",
- "sha2",
+ "sha2 0.8.2",
  "time 0.2.22",
  "tokio 0.2.22",
 ]
@@ -2859,7 +3373,47 @@ dependencies = [
  "base64 0.12.3",
  "blake2b_simd",
  "constant_time_eq",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a3679dd538c876a7b606f3bb951c8a20fc281a0ff7795f59f7cb490e3f979e1"
+dependencies = [
+ "cfg-if 0.1.10",
+ "ordered-multimap",
+]
+
+[[package]]
+name = "rust-s3"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a04bdd0f5118d06ef0e2daa658a9e5135282bcecfd6c46b11fddf47b1d5d736d"
+dependencies = [
+ "async-std",
+ "aws-creds",
+ "aws-region",
+ "base64 0.13.0",
+ "cfg-if 1.0.0",
+ "chrono",
+ "futures 0.3.7",
+ "hex 0.4.2",
+ "hmac 0.9.0",
+ "http 0.2.1",
+ "log",
+ "md5 0.7.0",
+ "percent-encoding",
+ "reqwest",
+ "serde",
+ "serde-xml-rs",
+ "serde_derive",
+ "sha2 0.9.3",
+ "simpl",
+ "tokio 0.2.22",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -2925,7 +3479,7 @@ dependencies = [
  "openssl-probe",
  "rustls 0.17.0",
  "schannel",
- "security-framework",
+ "security-framework 0.4.4",
 ]
 
 [[package]]
@@ -2988,10 +3542,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64808902d7d99f78eaddd2b4e2509713babc3dc3c85ad6f4c447680f3c01e535"
 dependencies = [
  "bitflags",
- "core-foundation",
- "core-foundation-sys",
+ "core-foundation 0.7.0",
+ "core-foundation-sys 0.7.0",
  "libc",
- "security-framework-sys",
+ "security-framework-sys 0.4.3",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1759c2e3c8580017a484a7ac56d3abc5a6c1feadf88db2f3633f12ae4268c69"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.1",
+ "core-foundation-sys 0.8.2",
+ "libc",
+ "security-framework-sys 2.0.0",
 ]
 
 [[package]]
@@ -3000,7 +3567,17 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17bf11d99252f512695eb468de5516e5cf75455521e69dfe343f3b74e4748405"
 dependencies = [
- "core-foundation-sys",
+ "core-foundation-sys 0.7.0",
+ "libc",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f99b9d5e26d2a71633cc4f2ebae7cc9f874044e0c351a27e17892d76dce5678b"
+dependencies = [
+ "core-foundation-sys 0.8.2",
  "libc",
 ]
 
@@ -3026,6 +3603,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06c64263859d87aa2eb554587e2d23183398d617427327cf2b3d0ed8c69e4800"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-xml-rs"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0bf1ba0696ccf0872866277143ff1fd14d22eec235d2b23702f95e6660f7dfa"
+dependencies = [
+ "log",
+ "serde",
+ "thiserror",
+ "xml-rs",
 ]
 
 [[package]]
@@ -3127,6 +3716,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa827a14b29ab7f44778d14a88d3cb76e949c45083f7dbfa507d0cb699dc12de"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if 1.0.0",
+ "cpuid-bool",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
 name = "shlex"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3140,6 +3742,12 @@ checksum = "ce32ea0c6c56d5eacaeb814fbed9960547021d3edd010ded1425f180536b20ab"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "simpl"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a30f10c911c0355f80f1c2faa8096efc4a58cdf8590b954d5b395efa071c711"
 
 [[package]]
 name = "slab"
@@ -3170,7 +3778,7 @@ checksum = "b1fa70dc5c8104ec096f4fe7ede7a221d35ae13dcd19ba1ad9a81d2cab9a1c44"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.1.57",
  "winapi 0.3.9",
 ]
 
@@ -3276,6 +3884,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
+name = "subtle"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
+
+[[package]]
 name = "syn"
 version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3339,6 +3953,20 @@ dependencies = [
  "quote 1.0.7",
  "syn 1.0.48",
  "unicode-xid 0.2.1",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "rand 0.8.3",
+ "redox_syscall 0.2.4",
+ "remove_dir_all",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3483,7 +4111,7 @@ dependencies = [
  "mio",
  "mio-named-pipes",
  "mio-uds",
- "pin-project-lite",
+ "pin-project-lite 0.1.11",
  "signal-hook-registry",
  "slab",
  "tokio-macros",
@@ -3528,7 +4156,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb2d1b8f4548dbf5e1f7818512e9c406860678f29c300cdf0ebac72d1a3a1671"
 dependencies = [
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "futures 0.1.30",
 ]
 
@@ -3571,7 +4199,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09bc590ec4ba8ba87652da2068d150dcada2cfa2e07faae270a5e0409aa51351"
 dependencies = [
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "futures 0.1.30",
  "lazy_static",
  "log",
@@ -3640,7 +4268,7 @@ checksum = "df720b6581784c118f0eb4310796b12b1d242a7eb95f716a8367855325c25f89"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-queue",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "futures 0.1.30",
  "lazy_static",
  "log",
@@ -3655,10 +4283,20 @@ version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93044f2d313c95ff1cb7809ce9a7a05735b012288a888b62d4434fd58c94f296"
 dependencies = [
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "futures 0.1.30",
  "slab",
  "tokio-executor",
+]
+
+[[package]]
+name = "tokio-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
+dependencies = [
+ "native-tls",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -3704,7 +4342,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite",
+ "pin-project-lite 0.1.11",
  "tokio 0.2.22",
 ]
 
@@ -3718,7 +4356,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite",
+ "pin-project-lite 0.1.11",
  "tokio 0.2.22",
 ]
 
@@ -3736,7 +4374,7 @@ checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
 dependencies = [
  "cfg-if 0.1.10",
  "log",
- "pin-project-lite",
+ "pin-project-lite 0.1.11",
  "tracing-core",
 ]
 
@@ -4022,6 +4660,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c"
 
 [[package]]
+name = "vec-arena"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eafc1b9b2dfc6f5529177b62cf806484db55b32dc7c9658a118e11bbeb33061d"
+
+[[package]]
 name = "version_check"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4032,6 +4676,12 @@ name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+
+[[package]]
+name = "waker-fn"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "walkdir"
@@ -4084,6 +4734,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ac64ead5ea5f05873d7c12b545865ca2b8d28adfc50a49b84770a3a97265d42"
 dependencies = [
  "cfg-if 0.1.10",
+ "serde",
+ "serde_json",
  "wasm-bindgen-macro",
 ]
 
@@ -4100,6 +4752,18 @@ dependencies = [
  "quote 1.0.7",
  "syn 1.0.48",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7866cab0aa01de1edf8b5d7936938a7e397ee50ce24119aef3e1eaa3b6171da"
+dependencies = [
+ "cfg-if 0.1.10",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -4179,6 +4843,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wepoll-sys"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fcb14dea929042224824779fbc82d9fab8d2e6d3cbc0ac404de8edf489e77ff"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "widestring"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4232,6 +4905,15 @@ name = "winreg"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "winreg"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
  "winapi 0.3.9",
 ]

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ AWS_SECRET_ACCESS_KEY= # or use an IAM role
 AWS_REGION=
 AWS_DYNAMODB_ENDPOINT= # optional, defaults to the default dynamodb endpoint for the given region.
 AWS_DYNAMODB_TABLE=
+AWS_S3_ENDPOINT= # optional, defaults to the default S3 endpoint for the given region
+AWS_S3_BUCKET=
 
 ENGINE_SERVER_PORT=5000
 

--- a/csml_engine/Cargo.toml
+++ b/csml_engine/Cargo.toml
@@ -20,7 +20,7 @@ edition = "2018"
 
 [features]
 mongo = ["mongodb", "bson"]
-dynamo = ["rusoto_core", "rusoto_dynamodb", "serde_dynamodb"]
+dynamo = ["rusoto_core", "rusoto_dynamodb", "serde_dynamodb", "rust-s3", ]
 
 [dependencies.mongodb]
 version = "0.9.2"
@@ -47,6 +47,10 @@ optional = true
 version = "0.44.0"
 default_features = false
 features = ["rustls"]
+optional = true
+
+[dependencies.rust-s3]
+version = "0.26.4"
 optional = true
 
 [dependencies]

--- a/csml_engine/src/data.rs
+++ b/csml_engine/src/data.rs
@@ -148,6 +148,7 @@ pub enum Next {
 pub enum EngineError {
     Serde(serde_json::Error),
     Io(std::io::Error),
+    Utf8(std::str::Utf8Error),
     Manager(String),
     Format(String),
     Interpreter(String),
@@ -166,6 +167,10 @@ pub enum EngineError {
     Rusoto(String),
     #[cfg(any(feature = "dynamo"))]
     SerdeDynamodb(serde_dynamodb::Error),
+    #[cfg(any(feature = "dynamo"))]
+    S3(s3::S3Error),
+    #[cfg(any(feature = "dynamo"))]
+    S3ErrorCode(u16),
 }
 
 impl From<serde_json::Error> for EngineError {
@@ -177,6 +182,12 @@ impl From<serde_json::Error> for EngineError {
 impl From<std::io::Error> for EngineError {
     fn from(e: std::io::Error) -> Self {
         EngineError::Io(e)
+    }
+}
+
+impl From<std::str::Utf8Error>  for EngineError {
+    fn from(e: std::str::Utf8Error) -> Self {
+        EngineError::Utf8(e)
     }
 }
 
@@ -230,5 +241,12 @@ impl<E: std::error::Error + 'static> From<rusoto_core::RusotoError<E>> for Engin
 impl From<serde_dynamodb::Error> for EngineError {
     fn from(e: serde_dynamodb::Error) -> Self {
         EngineError::SerdeDynamodb(e)
+    }
+}
+
+#[cfg(any(feature = "dynamo"))]
+impl From<s3::S3Error> for EngineError {
+    fn from(e: s3::S3Error) -> Self {
+        EngineError::S3(e)
     }
 }

--- a/csml_engine/src/db_connectors/dynamodb/aws_s3.rs
+++ b/csml_engine/src/db_connectors/dynamodb/aws_s3.rs
@@ -1,0 +1,70 @@
+extern crate s3;
+
+use crate::EngineError;
+use s3::bucket::Bucket;
+use s3::creds::Credentials;
+use s3::region::Region;
+use s3::S3Error;
+
+fn get_region(region: &str) -> Result<Region, S3Error> {
+    let region = region.parse::<Region>()?;
+
+    Ok(region)
+}
+
+pub fn get_bucket() -> Result<Bucket, EngineError> {
+    let region_name = match std::env::var("AWS_REGION") {
+        Ok(val) => Some(val),
+        Err(_) => None,
+    };
+    let s3_endpoint = match std::env::var("AWS_S3_ENDPOINT") {
+        Ok(val) => Some(val),
+        Err(_) => None,
+    };
+
+    let region = match (region_name, s3_endpoint) {
+        (Some(region_name), None) => get_region(&region_name)?,
+        (Some(region_name), Some(s3_endpoint)) => Region::Custom {
+            region: region_name,
+            endpoint: s3_endpoint,
+        },
+        _ => return Err(EngineError::Manager("Invalid AWS_S3 environment setup".to_owned()))
+    };
+
+    let credentials = Credentials::default().unwrap();
+
+    let bucket  = match std::env::var("AWS_S3_BUCKET") {
+        Ok(bucket) => bucket,
+        Err(_) => return Err(EngineError::Manager("Missing AWS_S3_BUCKET env var".to_owned())),
+    };
+
+    // Create Bucket in REGION
+    Ok(Bucket::new(&bucket, region, credentials)?)
+}
+
+pub fn put_object(bucket: &Bucket, key: &str, content: &[u8]) -> Result<(), EngineError> {
+    let (_, code) = bucket.put_object_with_content_type_blocking(key, content, "application/json")?;
+
+    match code {
+        code  if code == 200 => Ok(()),
+        code => Err(EngineError::S3ErrorCode(code))
+    }
+}
+
+pub fn get_object(bucket: &Bucket, key: &str) -> Result<Vec<u8>, EngineError> {
+    let (value, code) = bucket.get_object_blocking(key)?;
+
+    match code {
+        code if code == 200 => Ok(value),
+        code => Err(EngineError::S3ErrorCode(code))
+    }
+}
+
+pub fn delete_object(bucket: &Bucket, key: &str) -> Result<(), EngineError> {
+    let (_, code) = bucket.delete_object_blocking(key)?;
+
+    match code {
+        code if code == 204 => Ok(()),
+        code => Err(EngineError::S3ErrorCode(code))
+    }
+}

--- a/csml_engine/src/db_connectors/dynamodb/bot.rs
+++ b/csml_engine/src/db_connectors/dynamodb/bot.rs
@@ -1,16 +1,18 @@
 use crate::data::DynamoDbClient;
-use crate::db_connectors::{dynamodb::{Bot, DynamoDbKey, DynamoFlow}, BotVersion, };
+use crate::db_connectors::{dynamodb::{Bot, DynamoDbKey, aws_s3}, BotVersion,};
 use crate::{EngineError};
 use csml_interpreter::data::{csml_bot::DynamoBot, csml_flow::CsmlFlow};
 
 use rusoto_dynamodb::*;
-use std::{collections::HashMap};
+use s3::Bucket;
 
 use crate::db_connectors::dynamodb::utils::*;
 
 pub fn create_bot_version(
     bot_id: String,
     bot: String,
+    flows: &[u8],
+    bucket: &Bucket,
     db: &mut DynamoDbClient,
 ) -> Result<String, EngineError> {
     let data: Bot = Bot::new(bot_id, bot);
@@ -24,132 +26,21 @@ pub fn create_bot_version(
     let client = db.client.to_owned();
     let future = client.put_item(input);
     db.runtime.block_on(future)?;
+
+    let key = format!("bots/{}/versions/{}", &data.id, &data.version_id);
+    aws_s3::put_object(&bucket, &key, &flows)?;
+
     Ok(data.version_id.to_owned())
 }
 
-pub fn create_flows_batches(
-    bot_id: String,
-    version_id: String,
-    flows: Vec<CsmlFlow>,
-    db: &mut DynamoDbClient,
-) -> Result<(), EngineError> {
-    // We can only use BatchWriteItem on up to 25 items at once,
-    // so we need to split the messages to write into chunks of max
-    // 25 items.
-    for chunk in flows.chunks(25) {
-        let mut request_items = HashMap::new();
-
-        let mut items_to_write = vec![];
-        for flow in chunk {
-            let dynamo_flow: DynamoFlow = DynamoFlow::new(bot_id.clone(), version_id.clone(), flow);
-
-            items_to_write.push(WriteRequest {
-                put_request: Some(PutRequest {
-                    item: serde_dynamodb::to_hashmap(&dynamo_flow)?,
-                }),
-                ..Default::default()
-            });
-        }
-
-        request_items.insert(get_table_name()?, items_to_write);
-
-        let input = BatchWriteItemInput {
-            request_items,
-            ..Default::default()
-        };
-
-        let future = db.client.batch_write_item(input);
-
-        db.runtime.block_on(future)?;
-    }
-    Ok(())
-}
-
 pub fn get_flows(
-    bot_id: &str,
-    version_id: &str,
-    db: &mut DynamoDbClient,
+    bucket: &Bucket,
+    key: &str,
 ) -> Result<Vec<CsmlFlow>, EngineError> {
-    let mut flows = vec![];
-    let mut last_evaluated_key = None;
-
-    // retrieve all flows from dynamodb
-    loop {
-        let mut items = vec![];
-        let data = query_flows(bot_id, version_id, db, last_evaluated_key)?;
-        match data.items {
-            Some(val) => {
-                for item in val.iter() {
-                    let data: DynamoFlow = serde_dynamodb::from_hashmap(item.to_owned())?;
-
-                    let base64decoded = base64::decode(&data.flow).unwrap();
-                    let flow: CsmlFlow = bincode::deserialize(&base64decoded[..]).unwrap();
-                    items.push(flow);
-                }
-            }
-            _ => (),
-        };
-
-        flows.append(&mut items);
-        if let None = data.last_evaluated_key {
-            break;
-        }
-        last_evaluated_key = data.last_evaluated_key;
-    }
+    let object = aws_s3::get_object(bucket, key)?;
+    let flows: Vec<CsmlFlow> = serde_json::from_str(std::str::from_utf8(&object)?).unwrap();
 
     Ok(flows)
-}
-
-fn query_flows(
-    bot_id: &str,
-    version_id: &str,
-    db: &mut DynamoDbClient,
-    last_evaluated_key: Option<HashMap<String, AttributeValue>>,
-) -> Result<QueryOutput, EngineError> {
-    let hash = DynamoFlow::get_hash(&bot_id);
-
-    let key_cond_expr = "#hashKey = :hashVal AND begins_with(#rangeKey, :rangePrefix)".to_string();
-    let expr_attr_names = [
-        (String::from("#hashKey"), String::from("hash")),
-        (String::from("#rangeKey"), String::from("range")),
-    ]
-    .iter()
-    .cloned()
-    .collect();
-
-    let expr_attr_values = [
-        (
-            String::from(":hashVal"),
-            AttributeValue {
-                s: Some(hash),
-                ..Default::default()
-            },
-        ),
-        (
-            String::from(":rangePrefix"),
-            AttributeValue {
-                s: Some(format!("flow#{}", version_id)),
-                ..Default::default()
-            },
-        ),
-    ]
-    .iter()
-    .cloned()
-    .collect();
-
-    let input = QueryInput {
-        table_name: get_table_name()?,
-        key_condition_expression: Some(key_cond_expr),
-        expression_attribute_names: Some(expr_attr_names),
-        expression_attribute_values: Some(expr_attr_values),
-        scan_index_forward: Some(false),
-        select: Some(String::from("ALL_ATTRIBUTES")),
-        exclusive_start_key: last_evaluated_key,
-        ..Default::default()
-    };
-
-    let future = db.client.query(input);
-    Ok(db.runtime.block_on(future)?)
 }
 
 fn query_bot_version(
@@ -279,13 +170,14 @@ pub fn get_bot_versions(
 }
 
 pub fn get_bot_by_version_id(
-    id: &str,
+    version_id: &str,
     bot_id: &str,
+    bucket: &Bucket,
     db: &mut DynamoDbClient,
 ) -> Result<Option<BotVersion>, EngineError> {
     let item_key = DynamoDbKey {
         hash: Bot::get_hash(bot_id),
-        range: Bot::get_range(id),
+        range: Bot::get_range(version_id),
     };
 
     let input = GetItemInput {
@@ -303,7 +195,8 @@ pub fn get_bot_by_version_id(
             let base64decoded = base64::decode(&bot.bot).unwrap();
             let csml_bot: DynamoBot = bincode::deserialize(&base64decoded[..]).unwrap();
 
-            let flows = get_flows(&csml_bot.id, &bot.version_id, db)?;
+            let key = format!("bots/{}/versions/{}", bot_id, version_id);
+            let flows = get_flows(bucket, &key)?;
 
             Ok(Some(BotVersion{bot: csml_bot.to_bot(flows), version_id: bot.version_id, engine_version: env!("CARGO_PKG_VERSION").to_owned()}))}
         _ => Ok(None),
@@ -312,6 +205,7 @@ pub fn get_bot_by_version_id(
 
 pub fn get_last_bot_version(
     bot_id: &str,
+    bucket: &Bucket,
     db: &mut DynamoDbClient,
 ) -> Result<Option<BotVersion>, EngineError> {
     let hash = Bot::get_hash(bot_id);
@@ -372,7 +266,8 @@ pub fn get_last_bot_version(
     let base64decoded = base64::decode(&bot.bot).unwrap();
     let csml_bot: DynamoBot = bincode::deserialize(&base64decoded[..]).unwrap();
 
-    let flows = get_flows(&csml_bot.id, &bot.version_id, db)?;
+    let key = format!("bots/{}/versions/{}", bot_id, bot.version_id);
+    let flows = get_flows(bucket, &key)?;
 
     Ok(Some(BotVersion{bot: csml_bot.to_bot(flows), version_id: bot.version_id, engine_version: env!("CARGO_PKG_VERSION").to_owned()}))
 }
@@ -380,9 +275,12 @@ pub fn get_last_bot_version(
 pub fn delete_bot_version(
     bot_id: &str,
     version_id: &str,
+    bucket: &Bucket,
     db: &mut DynamoDbClient,
 ) -> Result<(), EngineError> {
-    delete_flows(bot_id, version_id, db)?;
+
+    let key = format!("bots/{}/versions/{}", bot_id, version_id);
+    aws_s3::delete_object(bucket, &key)?;
 
     let item_key = DynamoDbKey {
         hash: Bot::get_hash(bot_id),
@@ -401,77 +299,9 @@ pub fn delete_bot_version(
     Ok(())
 }
 
-fn flow_items_to_request_items(
-    items: Vec<HashMap<String, AttributeValue>>
-) -> Result<HashMap<String, Vec<WriteRequest> >, EngineError> {
-    let mut map = HashMap::new();
-    let mut write_requests = vec![];
-
-    for item in items {
-
-        let data: DynamoFlow = serde_dynamodb::from_hashmap(item.to_owned())?;
-
-        let key = serde_dynamodb::to_hashmap(&
-            DynamoDbKey {
-                hash: DynamoFlow::get_hash(&data.bot_id),
-                range: DynamoFlow::get_range(&data.version_id, &data.id),
-            }
-        )?;
-
-        write_requests.push(
-            WriteRequest{
-                delete_request: Some(
-                    DeleteRequest{
-                        key
-                    }
-                ),
-                put_request: None
-            }
-        );
-    }
-
-    map.insert(
-        get_table_name()?,
-        write_requests
-    );
-
-    Ok(map)
-}
-
-fn delete_flows(
-    bot_id: &str,
-    version_id: &str,
-    db: &mut DynamoDbClient,
-) -> Result<(), EngineError> {
-    let mut last_evaluated_key = None;
-
-    // retrieve all flows from dynamodb
-    loop {
-        let data = query_flows(bot_id, version_id, db, last_evaluated_key)?;
-
-        let request_items = match data.items {
-            None => return Ok(()),
-            Some(items) if items.len() == 0 => return Ok(()),
-            Some(items) => flow_items_to_request_items(items)?,
-        };
-
-        let input = BatchWriteItemInput {
-            request_items,
-            ..Default::default()
-        };
-
-        let future = db.client.batch_write_item(input);
-        db.runtime.block_on(future)?;
-
-        if let None = data.last_evaluated_key {
-            return Ok(())
-        }
-        last_evaluated_key = data.last_evaluated_key;
-    }
-}
-
 fn get_bot_version_batches_and_delete_flows(
     bot_id: &str,
+    bucket: &Bucket,
     db: &mut DynamoDbClient,
 ) -> Result<Vec<Vec<WriteRequest>>, EngineError>{
     let mut batches = vec!();
@@ -493,7 +323,9 @@ fn get_bot_version_batches_and_delete_flows(
         let mut write_requests = vec![];
         for item in items {
             let data: Bot = serde_dynamodb::from_hashmap(item.to_owned())?;
-            delete_flows(bot_id, &data.version_id, db)?;
+
+            let key = format!("bots/{}/versions/{}", bot_id, data.version_id);
+            aws_s3::delete_object(bucket, &key)?;
 
             let key = serde_dynamodb::to_hashmap(&
                 DynamoDbKey {
@@ -526,9 +358,10 @@ fn get_bot_version_batches_and_delete_flows(
 
 pub fn delete_bot_versions(
     bot_id: &str,
+    bucket: &Bucket,
     db: &mut DynamoDbClient,
 ) -> Result<(), EngineError> {
-    let batches = get_bot_version_batches_and_delete_flows(bot_id, db)?;
+    let batches = get_bot_version_batches_and_delete_flows(bot_id, bucket, db)?;
 
     for write_requests in batches {
         let request_items = [

--- a/csml_engine/src/db_connectors/dynamodb/messages.rs
+++ b/csml_engine/src/db_connectors/dynamodb/messages.rs
@@ -3,6 +3,7 @@ use crate::{encrypt::encrypt_data, ConversationInfo, EngineError};
 use rusoto_dynamodb::*;
 use std::collections::HashMap;
 
+
 use crate::db_connectors::dynamodb::utils::*;
 
 fn format_messages(

--- a/csml_engine/src/db_connectors/mod.rs
+++ b/csml_engine/src/db_connectors/mod.rs
@@ -14,13 +14,15 @@
  *   - MONGODB_PASSWORD
  *
  * - `dynamodb`: requires a DynamoDB-compatible database (on AWS, or dynamodb-local
- * for dev purposes). The following env vars are required (alternatively if deploying on AWS,
- * use IAM roles)
+ * for dev purposes). A S3-compatible storage is also needed for storing bots in the engine.
+ * The following env vars are required (alternatively if deploying on AWS, prefer using IAM roles)
  *   - AWS_REGION
  *   - AWS_ACCESS_KEY_ID
  *   - AWS_SECRET_ACCESS_KEY
  *   - AWS_DYNAMODB_TABLE
  *   - AWS_DYNAMODB_ENDPOINT optional, defaults to the default dynamodb endpoint for the given region.
+ *   - AWS_S3_BUCKET
+ *   - AWS_S3_ENDPOINT optional, defaults to the default S3 endpoint for the given region
  * Both AWS_REGION AND AWS_DYNAMODB_ENDPOINT must be set to use a custom dynamodb-compatible DB.
  *
  * If the ENGINE_DB_TYPE env var is not set, mongodb is used by default.

--- a/csml_server/static/index.html
+++ b/csml_server/static/index.html
@@ -56,8 +56,10 @@ MONGODB_PASSWORD=root
 AWS_REGION=eu-west-3
 AWS_ACCESS_KEY_ID=foo
 AWS_SECRET_ACCESS_KEY=bar
-AWS_DYNAMODB_ENDPOINT=http://localhost:8000 # optional
+AWS_DYNAMODB_ENDPOINT=http://localhost:8000 # optional, defaults to the default dynamodb endpoint for the given region
 AWS_DYNAMODB_TABLE=my-csml-engine-table
+AWS_S3_ENDPOINT= # optional, defaults to the default S3 endpoint for the given region
+AWS_S3_BUCKET=my-csml-engine-bucket
 
 ENGINE_SERVER_PORT=5000 # optional, defaults to 5000
 


### PR DESCRIPTION
Larger bots can take a serious toll on dynamodb WCUs (and to a lesser extent, RCUs). To make it easier to save large bots effectively, scalably and on the cheap, we should save them on an S3-compatible storage instead.

The drawback is that latency is increased. One way to improve that (and it would be a good idea anyway) would be to add a redis cache on versioned bots?