### PR TITLE
fix: install CA certificates in Ubuntu OS store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,7 +837,7 @@ checksum = "697c714f50560202b1f4e2e09cd50a421881c83e9025db75d15f276616f04f40"
 
 [[package]]
 name = "csml_engine"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "base64 0.13.0",
  "bincode",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "csml_engine_node"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "csml_engine",
  "csml_interpreter",
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "csml_interpreter"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "base64 0.13.0",
  "bincode",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "csml_server"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "actix-cors",
  "actix-files",

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM ubuntu:19.04
+FROM ubuntu:18.04
+
+RUN apt update && apt install -y ca-certificates && apt clean
+RUN update-ca-certificates
 
 WORKDIR /usr/src/csml
 

--- a/bindings/node/native/Cargo.toml
+++ b/bindings/node/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "csml_engine_node"
-version = "1.4.3"
+version = "1.4.4"
 authors = ["Alexis Merelo <alexis.merelo@clevy.io>"]
 license = "MIT"
 build = "build.rs"
@@ -17,7 +17,7 @@ neon-build = "0.4.0"
 [dependencies]
 neon = "0.4.0"
 neon-serde = "0.4.0"
-csml_engine = { version = "1.4.3", path = "../../../csml_engine", features = ["mongo", "dynamo"]}
-csml_interpreter = { version = "1.4.3", path = "../../../csml_interpreter"}
+csml_engine = { version = "1.4.4", path = "../../../csml_engine", features = ["mongo", "dynamo"]}
+csml_interpreter = { version = "1.4.4", path = "../../../csml_interpreter"}
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/csml_engine/Cargo.toml
+++ b/csml_engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "csml_engine"
-version = "1.4.3"
+version = "1.4.4"
 authors = [
     "Alexis Merelo <alexis.merelo@clevy.io>",
     "François Falala-Sechet <francois@clevy.io>",
@@ -56,7 +56,7 @@ features = ["rustls"]
 optional = true
 
 [dependencies]
-csml_interpreter = { version = "1.4.3", path = "../csml_interpreter" }
+csml_interpreter = { version = "1.4.4", path = "../csml_interpreter" }
 multimap = "0.8.2"
 md-5 = "0.9.1"
 chrono = "0.4"

--- a/csml_interpreter/Cargo.toml
+++ b/csml_interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "csml_interpreter"
-version = "1.4.3"
+version = "1.4.4"
 authors = [
     "Alexis Merelo <alexis.merelo@clevy.io>",
     "François Falala-Sechet <francois@clevy.io>",

--- a/csml_server/Cargo.toml
+++ b/csml_server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "csml_server"
-version = "1.4.3"
+version = "1.4.4"
 authors = ["François Falala-Sechet <francois@clevy.io>"]
 edition = "2018"
 

--- a/csml_server/swagger.yaml
+++ b/csml_server/swagger.yaml
@@ -1,6 +1,6 @@
 openapi: "3.0.0"
 info:
-  version: 1.4.3
+  version: 1.4.4
   title: CSML Engine
   description: CSML Engine Server API specifications
   termsOfService: http://csml.dev/terms/
@@ -305,7 +305,7 @@ components:
     EngineVersion:
       type: string
       description: The version of the engine this resource was handled with. Can be used for compatibility checks later on.
-      example: '1.4.3'
+      example: '1.4.4'
 
     BotModel:
       type: object


### PR DESCRIPTION
With [this recent upgrade of hyper-rustls](https://github.com/ctz/hyper-rustls/pull/125), we could not run CSML-engine anymore with no CA certificates installed as is the case by default in a blank ubuntu docker image.

This fixes that issue by installing the CA certificates at build time.