### PR TITLE
fix: Deploy to Heroku

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ DEBUG=true
 
 ### Deploy to Heroku
 
-<a href="https://heroku.com/deploy?template=https://github.com/CSML-by-Clevy/csml-engine/tree/masters">
+<a href="https://heroku.com/deploy?template=https://github.com/CSML-by-Clevy/csml-engine/tree/master">
   <img src="https://www.herokucdn.com/deploy/button.svg" alt="Deploy to Heroku">
 </a>
 

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
     "name": "CSML application",
     "description": "",
-    "repository": "https://github.com/CSML-by-Clevy/csml-engine/tree/feat/deploy-to-heroku",
+    "repository": "https://github.com/CSML-by-Clevy/csml-engine/tree/master",
     "success_url": "/",
     "keywords": ["rust", "csml"],
     "website": "https://www.csml.dev/",


### PR DESCRIPTION
- The deploy button was broken as the README points to a branch that does not exist. I have updated the branch name to `master` from `masters`

<img width="537" alt="Screenshot 2021-08-04 at 12 23 43 PM" src="https://user-images.githubusercontent.com/2246121/128135403-b4f19552-db17-4150-ac7f-08f8cf442b35.png">
