### PR TITLE
Feat/add additional info into primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1228,9 +1228,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.28"
+version = "0.8.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
+checksum = "a74ea89a0a1b98f6332de42c95baff457ada66d1cb4030f9ff151b2041a1c746"
 dependencies = [
  "cfg-if 1.0.0",
 ]

--- a/csml_engine/CSML/test/goto_flow/flows/flow6.csml
+++ b/csml_engine/CSML/test/goto_flow/flows/flow6.csml
@@ -5,6 +5,7 @@ start:
     remember int = 4
     remember float = 4.2
     remember vec = [21, 42, 84]
+    remember no_initialize = random
     goto step step1
 
 step1:
@@ -13,3 +14,4 @@ step1:
     say int.to_string()
     say float.to_string()
     say vec.to_string()
+    say random

--- a/csml_engine/tests/test_bot.rs
+++ b/csml_engine/tests/test_bot.rs
@@ -333,11 +333,14 @@ fn ok_test_memory() {
     let events = &["/flow6"];
     let messages = &[
         "flow6 start",
+        "< random > is used before it was saved in memory at line 8, column 30 at flow [flow6]",
         "{\"val\":1}",
         "message",
         "4",
         "4.2",
         "[21,42,84]",
+        "< random > is used before it was saved in memory at line 17, column 9 at flow [flow6]",
+        "Null",
     ];
 
     let channel_id = Uuid::new_v4().to_string();
@@ -360,10 +363,12 @@ fn ok_test_memory() {
             Ok(obj) => {
                 let messages = obj["messages"].as_array().unwrap();
                 for message in messages.iter() {
+                    let content_type = message["payload"]["content_type"].as_str().unwrap();
+
                     output_message.push(
-                        message["payload"]["content"]["text"]
+                        message["payload"]["content"][content_type]
                             .as_str()
-                            .unwrap()
+                            .unwrap_or("Null")
                             .to_owned(),
                     );
                 }

--- a/csml_interpreter/src/data/memories.rs
+++ b/csml_interpreter/src/data/memories.rs
@@ -1,4 +1,5 @@
 use crate::data::Literal;
+use crate::data::primitive::{PrimitiveObject};
 
 #[derive(Debug, Clone)]
 pub enum MemoryType {
@@ -17,7 +18,15 @@ pub struct Memory {
 impl Memory {
     pub fn new(key: String, value: Literal) -> Self {
         let content_type = &value.content_type;
-        let value = value.primitive.format_mem(content_type, true);
+
+        let value = if let Some(obj) = value.additional_info {
+            serde_json::json!({
+                "_additional_info": PrimitiveObject::obj_literal_to_json(&obj),
+                "value": value.primitive.format_mem(content_type, true)
+            })
+        } else {
+            value.primitive.format_mem(content_type, true)
+        };
 
         Self { key, value }
     }

--- a/csml_interpreter/src/data/msg.rs
+++ b/csml_interpreter/src/data/msg.rs
@@ -51,7 +51,10 @@ impl MSG {
                     sender.send(msg).unwrap();
                 }
 
-                PrimitiveNull::get_literal(err.position.interval)
+                let mut error_lit = PrimitiveNull::get_literal(err.position.interval);
+                error_lit.additional_info = err.additional_info;
+
+                error_lit
             }
         }
     }

--- a/csml_interpreter/src/data/primitive.rs
+++ b/csml_interpreter/src/data/primitive.rs
@@ -78,6 +78,7 @@ pub trait Primitive: Send {
         &mut self,
         name: &str,
         args: &HashMap<String, Literal>,
+        additional_info: &Option<HashMap<String, Literal>>,
         interval: Interval,
         content_type: &ContentType,
         data: &mut Data,
@@ -110,6 +111,7 @@ impl dyn Primitive {
         &mut self,
         name: &str,
         args: &HashMap<String, Literal>,
+        additional_info: &Option<HashMap<String, Literal>>,
         interval: Interval,
         content_type: &ContentType,
         mem_update: &mut bool,
@@ -120,7 +122,7 @@ impl dyn Primitive {
         *mem_update = false;
 
         let (res, right) =
-            self.do_exec(name, args, interval, content_type, data, msg_data, sender)?;
+            self.do_exec(name, args, additional_info, interval, content_type, data, msg_data, sender)?;
         if right == Right::Write {
             *mem_update = true;
         }

--- a/csml_interpreter/src/data/primitive/array.rs
+++ b/csml_interpreter/src/data/primitive/array.rs
@@ -1,5 +1,6 @@
 use crate::data::position::Position;
 use crate::data::{
+    literal,
     literal::ContentType,
     primitive::{
         Primitive, PrimitiveBoolean, PrimitiveClosure, PrimitiveInt, PrimitiveNull,
@@ -26,6 +27,7 @@ use std::{collections::HashMap, sync::mpsc};
 type PrimitiveMethod = fn(
     array: &mut PrimitiveArray,
     args: &HashMap<String, Literal>,
+    additional_info: &Option<HashMap<String, Literal>>,
     interval: Interval,
     data: &mut Data,
     msg_data: &mut MessageData,
@@ -37,8 +39,10 @@ const FUNCTIONS: phf::Map<&'static str, (PrimitiveMethod, Right)> = phf_map! {
     "is_int" => (PrimitiveArray::is_int as PrimitiveMethod, Right::Read),
     "is_float" => (PrimitiveArray::is_float as PrimitiveMethod, Right::Read),
     "type_of" => (PrimitiveArray::type_of as PrimitiveMethod, Right::Read),
+    "get_info" => (PrimitiveArray::get_info as PrimitiveMethod, Right::Read),
+    "is_error" => (PrimitiveArray::is_error as PrimitiveMethod, Right::Read),
     "to_string" => (PrimitiveArray::to_string as PrimitiveMethod, Right::Read),
-
+    
     "find" => (PrimitiveArray::find as PrimitiveMethod, Right::Read),
     "is_empty" => (PrimitiveArray::is_empty as PrimitiveMethod, Right::Read),
     "insert_at" => (PrimitiveArray::insert_at as PrimitiveMethod, Right::Write),
@@ -92,6 +96,7 @@ impl PrimitiveArray {
     fn is_number(
         _array: &mut PrimitiveArray,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         interval: Interval,
         data: &mut Data,
         _msg_data: &mut MessageData,
@@ -112,6 +117,7 @@ impl PrimitiveArray {
     fn is_int(
         _array: &mut PrimitiveArray,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         interval: Interval,
         data: &mut Data,
         _msg_data: &mut MessageData,
@@ -132,6 +138,7 @@ impl PrimitiveArray {
     fn is_float(
         _array: &mut PrimitiveArray,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         interval: Interval,
         data: &mut Data,
         _msg_data: &mut MessageData,
@@ -152,6 +159,7 @@ impl PrimitiveArray {
     fn type_of(
         _array: &mut PrimitiveArray,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         interval: Interval,
         data: &mut Data,
         _msg_data: &mut MessageData,
@@ -169,9 +177,39 @@ impl PrimitiveArray {
         Ok(PrimitiveString::get_literal("array", interval))
     }
 
+    fn get_info(
+        _array: &mut PrimitiveArray,
+        args: &HashMap<String, Literal>,
+        additional_info: &Option<HashMap<String, Literal>>,
+        interval: Interval,
+        data: &mut Data,
+        _msg_data: &mut MessageData,
+        _sender: &Option<mpsc::Sender<MSG>>,
+    ) -> Result<Literal, ErrorInfo> {
+        literal::get_info(args, additional_info, interval, data)
+    }
+
+    fn is_error(
+        _array: &mut PrimitiveArray,
+        _args: &HashMap<String, Literal>,
+        additional_info: &Option<HashMap<String, Literal>>,
+        interval: Interval,
+        _data: &mut Data,
+        _msg_data: &mut MessageData,
+        _sender: &Option<mpsc::Sender<MSG>>,
+    ) -> Result<Literal, ErrorInfo> {
+        match additional_info {
+            Some(map) if map.contains_key("error") => {
+                Ok(PrimitiveBoolean::get_literal(true, interval))
+            }
+            _ => Ok(PrimitiveBoolean::get_literal(false, interval))
+        }
+    }
+
     fn to_string(
         array: &mut PrimitiveArray,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         interval: Interval,
         data: &mut Data,
         _msg_data: &mut MessageData,
@@ -194,6 +232,7 @@ impl PrimitiveArray {
     fn find(
         array: &mut PrimitiveArray,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         interval: Interval,
         data: &mut Data,
         _msg_data: &mut MessageData,
@@ -236,6 +275,7 @@ impl PrimitiveArray {
     fn is_empty(
         array: &mut PrimitiveArray,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         interval: Interval,
         data: &mut Data,
         _msg_data: &mut MessageData,
@@ -258,6 +298,7 @@ impl PrimitiveArray {
     fn insert_at(
         array: &mut PrimitiveArray,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         interval: Interval,
         data: &mut Data,
         _msg_data: &mut MessageData,
@@ -314,6 +355,7 @@ impl PrimitiveArray {
     fn index_of(
         array: &mut PrimitiveArray,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         interval: Interval,
         data: &mut Data,
         _msg_data: &mut MessageData,
@@ -350,6 +392,7 @@ impl PrimitiveArray {
     fn join(
         array: &mut PrimitiveArray,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         interval: Interval,
         data: &mut Data,
         _msg_data: &mut MessageData,
@@ -398,6 +441,7 @@ impl PrimitiveArray {
     fn length(
         array: &mut PrimitiveArray,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         interval: Interval,
         data: &mut Data,
         _msg_data: &mut MessageData,
@@ -420,6 +464,7 @@ impl PrimitiveArray {
     fn one_of(
         array: &mut PrimitiveArray,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         interval: Interval,
         data: &mut Data,
         _msg_data: &mut MessageData,
@@ -447,6 +492,7 @@ impl PrimitiveArray {
     fn push(
         array: &mut PrimitiveArray,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         interval: Interval,
         data: &mut Data,
         _msg_data: &mut MessageData,
@@ -486,6 +532,7 @@ impl PrimitiveArray {
     fn pop(
         array: &mut PrimitiveArray,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         interval: Interval,
         data: &mut Data,
         _msg_data: &mut MessageData,
@@ -512,6 +559,7 @@ impl PrimitiveArray {
     fn remove_at(
         array: &mut PrimitiveArray,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         interval: Interval,
         data: &mut Data,
         _msg_data: &mut MessageData,
@@ -556,6 +604,7 @@ impl PrimitiveArray {
     fn shuffle(
         array: &mut PrimitiveArray,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         interval: Interval,
         data: &mut Data,
         _msg_data: &mut MessageData,
@@ -580,6 +629,7 @@ impl PrimitiveArray {
     fn slice(
         array: &mut PrimitiveArray,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         interval: Interval,
         data: &mut Data,
         _msg_data: &mut MessageData,
@@ -696,6 +746,7 @@ impl PrimitiveArray {
     fn map(
         array: &mut PrimitiveArray,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         interval: Interval,
         data: &mut Data,
         msg_data: &mut MessageData,
@@ -750,6 +801,7 @@ impl PrimitiveArray {
     fn filter(
         array: &mut PrimitiveArray,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         interval: Interval,
         data: &mut Data,
         msg_data: &mut MessageData,
@@ -807,6 +859,7 @@ impl PrimitiveArray {
     fn reduce(
         array: &mut PrimitiveArray,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         interval: Interval,
         data: &mut Data,
         msg_data: &mut MessageData,
@@ -878,6 +931,7 @@ impl PrimitiveArray {
         Literal {
             content_type: "array".to_owned(),
             primitive,
+            additional_info: None,
             interval,
         }
     }
@@ -1032,6 +1086,7 @@ impl Primitive for PrimitiveArray {
         &mut self,
         name: &str,
         args: &HashMap<String, Literal>,
+        additional_info: &Option<HashMap<String, Literal>>,
         interval: Interval,
         _content_type: &ContentType,
         data: &mut Data,
@@ -1039,7 +1094,7 @@ impl Primitive for PrimitiveArray {
         sender: &Option<mpsc::Sender<MSG>>,
     ) -> Result<(Literal, Right), ErrorInfo> {
         if let Some((f, right)) = FUNCTIONS.get(name) {
-            let res = f(self, args, interval, data, msg_data, sender)?;
+            let res = f(self, args, additional_info, interval, data, msg_data, sender)?;
 
             return Ok((res, *right));
         }

--- a/csml_interpreter/src/data/primitive/float.rs
+++ b/csml_interpreter/src/data/primitive/float.rs
@@ -1,5 +1,6 @@
 use crate::data::primitive::tools::check_division_by_zero_f64;
 use crate::data::{
+    literal,
     ast::Interval,
     error_info::ErrorInfo,
     literal::ContentType,
@@ -24,6 +25,7 @@ use std::{collections::HashMap, sync::mpsc};
 type PrimitiveMethod = fn(
     float: &mut PrimitiveFloat,
     args: &HashMap<String, Literal>,
+    additional_info: &Option<HashMap<String, Literal>>,
     data: &mut Data,
     interval: Interval,
 ) -> Result<Literal, ErrorInfo>;
@@ -33,6 +35,8 @@ const FUNCTIONS: phf::Map<&'static str, (PrimitiveMethod, Right)> = phf_map! {
     "is_int" => (PrimitiveFloat::is_int as PrimitiveMethod, Right::Read),
     "is_float" => (PrimitiveFloat::is_float as PrimitiveMethod, Right::Read),
     "type_of" => (PrimitiveFloat::type_of as PrimitiveMethod, Right::Read),
+    "is_error" => (PrimitiveFloat::is_error as PrimitiveMethod, Right::Read),
+    "get_info" => (PrimitiveFloat::get_info as PrimitiveMethod, Right::Read),
     "to_string" => (PrimitiveFloat::to_string as PrimitiveMethod, Right::Read),
 
     "precision" => (PrimitiveFloat::precision as PrimitiveMethod, Right::Read),
@@ -61,6 +65,7 @@ impl PrimitiveFloat {
     fn is_number(
         _float: &mut PrimitiveFloat,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
     ) -> Result<Literal, ErrorInfo> {
@@ -79,6 +84,7 @@ impl PrimitiveFloat {
     fn is_int(
         _float: &mut PrimitiveFloat,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
     ) -> Result<Literal, ErrorInfo> {
@@ -97,6 +103,7 @@ impl PrimitiveFloat {
     fn is_float(
         _float: &mut PrimitiveFloat,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
     ) -> Result<Literal, ErrorInfo> {
@@ -115,6 +122,7 @@ impl PrimitiveFloat {
     fn type_of(
         _float: &mut PrimitiveFloat,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
     ) -> Result<Literal, ErrorInfo> {
@@ -130,9 +138,35 @@ impl PrimitiveFloat {
         Ok(PrimitiveString::get_literal("float", interval))
     }
 
+    fn get_info(
+        _float: &mut PrimitiveFloat,
+        args: &HashMap<String, Literal>,
+        additional_info: &Option<HashMap<String, Literal>>,
+        data: &mut Data,
+        interval: Interval,
+    ) -> Result<Literal, ErrorInfo> {
+        literal::get_info(args, additional_info, interval, data)
+    }
+
+    fn is_error(
+        _float: &mut PrimitiveFloat,
+        _args: &HashMap<String, Literal>,
+        additional_info: &Option<HashMap<String, Literal>>,
+        _data: &mut Data,
+        interval: Interval,
+    ) -> Result<Literal, ErrorInfo> {
+        match additional_info {
+            Some(map) if map.contains_key("error") => {
+                Ok(PrimitiveBoolean::get_literal(true, interval))
+            }
+            _ => Ok(PrimitiveBoolean::get_literal(false, interval))
+        }
+    }
+
     fn to_string(
         float: &mut PrimitiveFloat,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
     ) -> Result<Literal, ErrorInfo> {
@@ -153,6 +187,7 @@ impl PrimitiveFloat {
     fn abs(
         float: &mut PrimitiveFloat,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
     ) -> Result<Literal, ErrorInfo> {
@@ -173,6 +208,7 @@ impl PrimitiveFloat {
     fn cos(
         float: &mut PrimitiveFloat,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
     ) -> Result<Literal, ErrorInfo> {
@@ -193,6 +229,7 @@ impl PrimitiveFloat {
     fn ceil(
         float: &mut PrimitiveFloat,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
     ) -> Result<Literal, ErrorInfo> {
@@ -213,6 +250,7 @@ impl PrimitiveFloat {
     fn precision(
         float: &mut PrimitiveFloat,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
     ) -> Result<Literal, ErrorInfo> {
@@ -245,6 +283,7 @@ impl PrimitiveFloat {
     fn floor(
         float: &mut PrimitiveFloat,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
     ) -> Result<Literal, ErrorInfo> {
@@ -265,6 +304,7 @@ impl PrimitiveFloat {
     fn pow(
         float: &mut PrimitiveFloat,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
     ) -> Result<Literal, ErrorInfo> {
@@ -328,6 +368,7 @@ impl PrimitiveFloat {
     fn round(
         float: &mut PrimitiveFloat,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
     ) -> Result<Literal, ErrorInfo> {
@@ -348,6 +389,7 @@ impl PrimitiveFloat {
     fn sin(
         float: &mut PrimitiveFloat,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
     ) -> Result<Literal, ErrorInfo> {
@@ -368,6 +410,7 @@ impl PrimitiveFloat {
     fn sqrt(
         float: &mut PrimitiveFloat,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
     ) -> Result<Literal, ErrorInfo> {
@@ -388,6 +431,7 @@ impl PrimitiveFloat {
     fn tan(
         float: &mut PrimitiveFloat,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
     ) -> Result<Literal, ErrorInfo> {
@@ -408,6 +452,7 @@ impl PrimitiveFloat {
     fn to_int(
         float: &mut PrimitiveFloat,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
     ) -> Result<Literal, ErrorInfo> {
@@ -426,6 +471,7 @@ impl PrimitiveFloat {
     fn to_float(
         float: &mut PrimitiveFloat,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
     ) -> Result<Literal, ErrorInfo> {
@@ -457,6 +503,7 @@ impl PrimitiveFloat {
         Literal {
             content_type: "float".to_owned(),
             primitive,
+            additional_info: None,
             interval,
         }
     }
@@ -644,6 +691,7 @@ impl Primitive for PrimitiveFloat {
             Literal {
                 content_type: "float".to_owned(),
                 primitive: Box::new(PrimitiveString::new(&self.to_string())),
+                additional_info: None,
                 interval: Interval {
                     start_column: 0,
                     start_line: 0,
@@ -676,6 +724,7 @@ impl Primitive for PrimitiveFloat {
         &mut self,
         name: &str,
         args: &HashMap<String, Literal>,
+        additional_info: &Option<HashMap<String, Literal>>,
         interval: Interval,
         _content_type: &ContentType,
         data: &mut Data,
@@ -683,7 +732,7 @@ impl Primitive for PrimitiveFloat {
         _sender: &Option<mpsc::Sender<MSG>>,
     ) -> Result<(Literal, Right), ErrorInfo> {
         if let Some((f, right)) = FUNCTIONS.get(name) {
-            let res = f(self, args, data, interval)?;
+            let res = f(self, args, additional_info, data, interval)?;
 
             return Ok((res, *right));
         }

--- a/csml_interpreter/src/data/primitive/int.rs
+++ b/csml_interpreter/src/data/primitive/int.rs
@@ -1,5 +1,5 @@
 use crate::data::error_info::ErrorInfo;
-use crate::data::literal::ContentType;
+use crate::data::{literal, literal::ContentType};
 use crate::data::position::Position;
 use crate::data::primitive::boolean::PrimitiveBoolean;
 use crate::data::primitive::float::PrimitiveFloat;
@@ -22,6 +22,7 @@ use std::{collections::HashMap, sync::mpsc};
 type PrimitiveMethod = fn(
     int: &mut PrimitiveInt,
     args: &HashMap<String, Literal>,
+    additional_info: &Option<HashMap<String, Literal>>,
     data: &mut Data,
     interval: Interval,
 ) -> Result<Literal, ErrorInfo>;
@@ -31,6 +32,8 @@ const FUNCTIONS: phf::Map<&'static str, (PrimitiveMethod, Right)> = phf_map! {
     "is_int" => (PrimitiveInt::is_int as PrimitiveMethod, Right::Read),
     "is_float" => (PrimitiveInt::is_float as PrimitiveMethod, Right::Read),
     "type_of" => (PrimitiveInt::type_of as PrimitiveMethod, Right::Read),
+    "is_error" => (PrimitiveInt::is_error as PrimitiveMethod, Right::Read),
+    "get_info" => (PrimitiveInt::get_info as PrimitiveMethod, Right::Read),
     "to_string" => (PrimitiveInt::to_string as PrimitiveMethod, Right::Read),
 
     "precision" => (PrimitiveInt::precision as PrimitiveMethod, Right::Read),
@@ -59,6 +62,7 @@ impl PrimitiveInt {
     fn is_number(
         _int: &mut PrimitiveInt,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
     ) -> Result<Literal, ErrorInfo> {
@@ -77,6 +81,7 @@ impl PrimitiveInt {
     fn is_int(
         _int: &mut PrimitiveInt,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
     ) -> Result<Literal, ErrorInfo> {
@@ -95,6 +100,7 @@ impl PrimitiveInt {
     fn is_float(
         _int: &mut PrimitiveInt,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
     ) -> Result<Literal, ErrorInfo> {
@@ -113,6 +119,7 @@ impl PrimitiveInt {
     fn type_of(
         _int: &mut PrimitiveInt,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
     ) -> Result<Literal, ErrorInfo> {
@@ -128,9 +135,35 @@ impl PrimitiveInt {
         Ok(PrimitiveString::get_literal("int", interval))
     }
 
+    fn get_info(
+        _int: &mut PrimitiveInt,
+        args: &HashMap<String, Literal>,
+        additional_info: &Option<HashMap<String, Literal>>,
+        data: &mut Data,
+        interval: Interval,
+    ) -> Result<Literal, ErrorInfo> {
+        literal::get_info(args, additional_info, interval, data)
+    }
+
+    fn is_error(
+        _int: &mut PrimitiveInt,
+        _args: &HashMap<String, Literal>,
+        additional_info: &Option<HashMap<String, Literal>>,
+        _data: &mut Data,
+        interval: Interval,
+    ) -> Result<Literal, ErrorInfo> {
+        match additional_info {
+            Some(map) if map.contains_key("error") => {
+                Ok(PrimitiveBoolean::get_literal(true, interval))
+            }
+            _ => Ok(PrimitiveBoolean::get_literal(false, interval))
+        }
+    }
+
     fn to_string(
         int: &mut PrimitiveInt,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
     ) -> Result<Literal, ErrorInfo> {
@@ -151,6 +184,7 @@ impl PrimitiveInt {
     fn abs(
         int: &mut PrimitiveInt,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
     ) -> Result<Literal, ErrorInfo> {
@@ -174,6 +208,7 @@ impl PrimitiveInt {
     fn cos(
         int: &mut PrimitiveInt,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
     ) -> Result<Literal, ErrorInfo> {
@@ -199,6 +234,7 @@ impl PrimitiveInt {
     fn ceil(
         int: &mut PrimitiveInt,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
     ) -> Result<Literal, ErrorInfo> {
@@ -222,6 +258,7 @@ impl PrimitiveInt {
     fn precision(
         int: &mut PrimitiveInt,
         _args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         _data: &mut Data,
         interval: Interval,
     ) -> Result<Literal, ErrorInfo> {
@@ -231,6 +268,7 @@ impl PrimitiveInt {
     fn floor(
         int: &mut PrimitiveInt,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
     ) -> Result<Literal, ErrorInfo> {
@@ -254,6 +292,7 @@ impl PrimitiveInt {
     fn pow(
         int: &mut PrimitiveInt,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
     ) -> Result<Literal, ErrorInfo> {
@@ -322,6 +361,7 @@ impl PrimitiveInt {
     fn round(
         int: &mut PrimitiveInt,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
     ) -> Result<Literal, ErrorInfo> {
@@ -345,6 +385,7 @@ impl PrimitiveInt {
     fn sin(
         int: &mut PrimitiveInt,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
     ) -> Result<Literal, ErrorInfo> {
@@ -370,6 +411,7 @@ impl PrimitiveInt {
     fn sqrt(
         int: &mut PrimitiveInt,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
     ) -> Result<Literal, ErrorInfo> {
@@ -395,6 +437,7 @@ impl PrimitiveInt {
     fn tan(
         int: &mut PrimitiveInt,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
     ) -> Result<Literal, ErrorInfo> {
@@ -420,6 +463,7 @@ impl PrimitiveInt {
     fn to_int(
         int: &mut PrimitiveInt,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
     ) -> Result<Literal, ErrorInfo> {
@@ -438,6 +482,7 @@ impl PrimitiveInt {
     fn to_float(
         int: &mut PrimitiveInt,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
     ) -> Result<Literal, ErrorInfo> {
@@ -469,6 +514,7 @@ impl PrimitiveInt {
         Literal {
             content_type: "int".to_owned(),
             primitive,
+            additional_info: None,
             interval,
         }
     }
@@ -649,6 +695,7 @@ impl Primitive for PrimitiveInt {
             Literal {
                 content_type: "int".to_owned(),
                 primitive: Box::new(PrimitiveString::new(&self.to_string())),
+                additional_info: None,
                 interval: Interval {
                     start_column: 0,
                     start_line: 0,
@@ -681,6 +728,7 @@ impl Primitive for PrimitiveInt {
         &mut self,
         name: &str,
         args: &HashMap<String, Literal>,
+        additional_info: &Option<HashMap<String, Literal>>,
         interval: Interval,
         _content_type: &ContentType,
         data: &mut Data,
@@ -688,7 +736,7 @@ impl Primitive for PrimitiveInt {
         _sender: &Option<mpsc::Sender<MSG>>,
     ) -> Result<(Literal, Right), ErrorInfo> {
         if let Some((f, right)) = FUNCTIONS.get(name) {
-            let res = f(self, args, data, interval)?;
+            let res = f(self, args, additional_info, data, interval)?;
 
             return Ok((res, *right));
         }

--- a/csml_interpreter/src/data/primitive/object.rs
+++ b/csml_interpreter/src/data/primitive/object.rs
@@ -1,6 +1,7 @@
 use crate::data::error_info::ErrorInfo;
 use crate::data::position::Position;
 use crate::data::{
+    literal,
     ast::Interval,
     literal::ContentType,
     message::Message,
@@ -64,19 +65,19 @@ const FUNCTIONS_JWT: phf::Map<&'static str, (PrimitiveMethod, Right)> = phf_map!
 };
 
 const FUNCTIONS_CRYPTO: phf::Map<&'static str, (PrimitiveMethod, Right)> = phf_map! {
-        "create_hmac" => (PrimitiveObject::create_hmac as PrimitiveMethod, Right::Read),
-        "create_hash" => (PrimitiveObject::create_hash as PrimitiveMethod, Right::Read),
-        "digest" => (PrimitiveObject::digest as PrimitiveMethod, Right::Read),
+    "create_hmac" => (PrimitiveObject::create_hmac as PrimitiveMethod, Right::Read),
+    "create_hash" => (PrimitiveObject::create_hash as PrimitiveMethod, Right::Read),
+    "digest" => (PrimitiveObject::digest as PrimitiveMethod, Right::Read),
 };
 
 const FUNCTIONS_BASE64: phf::Map<&'static str, (PrimitiveMethod, Right)> = phf_map! {
-        "encode" => (PrimitiveObject::base64_encode as PrimitiveMethod, Right::Read),
-        "decode" => (PrimitiveObject::base64_decode as PrimitiveMethod, Right::Read),
+    "encode" => (PrimitiveObject::base64_encode as PrimitiveMethod, Right::Read),
+    "decode" => (PrimitiveObject::base64_decode as PrimitiveMethod, Right::Read),
 };
 
 const FUNCTIONS_HEX: phf::Map<&'static str, (PrimitiveMethod, Right)> = phf_map! {
-        "encode" => (PrimitiveObject::hex_encode as PrimitiveMethod, Right::Read),
-        "decode" => (PrimitiveObject::hex_decode as PrimitiveMethod, Right::Read),
+    "encode" => (PrimitiveObject::hex_encode as PrimitiveMethod, Right::Read),
+    "decode" => (PrimitiveObject::hex_decode as PrimitiveMethod, Right::Read),
 };
 
 const FUNCTIONS_EVENT: phf::Map<&'static str, (PrimitiveMethod, Right)> = phf_map! {
@@ -92,6 +93,8 @@ const FUNCTIONS_READ: phf::Map<&'static str, (PrimitiveMethod, Right)> = phf_map
     "is_int" => (PrimitiveObject::is_int as PrimitiveMethod, Right::Read),
     "is_float" => (PrimitiveObject::is_float as PrimitiveMethod, Right::Read),
     "type_of" => (PrimitiveObject::type_of as PrimitiveMethod, Right::Read),
+    "get_info" => (PrimitiveObject::get_info as PrimitiveMethod, Right::Read),
+    "is_error" => (PrimitiveObject::is_error as PrimitiveMethod, Right::Read),
     "to_string" => (PrimitiveObject::to_string as PrimitiveMethod, Right::Read),
 
     "contains" => (PrimitiveObject::contains as PrimitiveMethod, Right::Read),
@@ -112,6 +115,7 @@ const FUNCTIONS_WRITE: phf::Map<&'static str, (PrimitiveMethod, Right)> = phf_ma
 type PrimitiveMethod = fn(
     object: &mut PrimitiveObject,
     args: &HashMap<String, Literal>,
+    additional_info: &Option<HashMap<String, Literal>>,
     data: &mut Data,
     interval: Interval,
     content_type: &str,
@@ -130,6 +134,7 @@ impl PrimitiveObject {
     fn set(
         object: &mut PrimitiveObject,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
         _content_type: &str,
@@ -174,6 +179,7 @@ impl PrimitiveObject {
     fn auth(
         object: &mut PrimitiveObject,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
         _content_type: &str,
@@ -241,6 +247,7 @@ impl PrimitiveObject {
     fn query(
         object: &mut PrimitiveObject,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
         _content_type: &str,
@@ -284,6 +291,7 @@ impl PrimitiveObject {
     fn get_http(
         object: &mut PrimitiveObject,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
         _content_type: &str,
@@ -316,6 +324,7 @@ impl PrimitiveObject {
     fn post(
         object: &mut PrimitiveObject,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         _data: &mut Data,
         interval: Interval,
         _content_type: &str,
@@ -342,6 +351,7 @@ impl PrimitiveObject {
     fn put(
         object: &mut PrimitiveObject,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         _data: &mut Data,
         interval: Interval,
         _content_type: &str,
@@ -368,6 +378,7 @@ impl PrimitiveObject {
     fn delete(
         object: &mut PrimitiveObject,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         _data: &mut Data,
         interval: Interval,
         _content_type: &str,
@@ -394,6 +405,7 @@ impl PrimitiveObject {
     fn patch(
         object: &mut PrimitiveObject,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         _data: &mut Data,
         interval: Interval,
         _content_type: &str,
@@ -422,6 +434,7 @@ impl PrimitiveObject {
     fn send(
         object: &mut PrimitiveObject,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
         _content_type: &str,
@@ -471,6 +484,7 @@ impl PrimitiveObject {
     fn credentials(
         object: &mut PrimitiveObject,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
         _content_type: &str,
@@ -536,6 +550,7 @@ impl PrimitiveObject {
     fn port(
         object: &mut PrimitiveObject,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
         _content_type: &str,
@@ -581,6 +596,7 @@ impl PrimitiveObject {
     fn smtp_tls(
         object: &mut PrimitiveObject,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
         _content_type: &str,
@@ -626,6 +642,7 @@ impl PrimitiveObject {
     fn smtp_send(
         object: &mut PrimitiveObject,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
         _content_type: &str,
@@ -672,6 +689,7 @@ impl PrimitiveObject {
     fn set_date_at(
         object: &mut PrimitiveObject,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         _data: &mut Data,
         interval: Interval,
         _content_type: &str,
@@ -709,6 +727,7 @@ impl PrimitiveObject {
     fn unix(
         object: &mut PrimitiveObject,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
         _content_type: &str,
@@ -762,6 +781,7 @@ impl PrimitiveObject {
     fn add_time(
         object: &mut PrimitiveObject,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
         _content_type: &str,
@@ -811,6 +831,7 @@ impl PrimitiveObject {
     fn sub_time(
         object: &mut PrimitiveObject,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
         _content_type: &str,
@@ -860,6 +881,7 @@ impl PrimitiveObject {
     fn parse_date(
         _object: &mut PrimitiveObject,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
         _content_type: &str,
@@ -883,6 +905,7 @@ impl PrimitiveObject {
     fn date_format(
         object: &mut PrimitiveObject,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
         _content_type: &str,
@@ -934,6 +957,7 @@ impl PrimitiveObject {
     fn jwt_sign(
         object: &mut PrimitiveObject,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
         _content_type: &str,
@@ -999,6 +1023,7 @@ impl PrimitiveObject {
     fn jwt_decode(
         object: &mut PrimitiveObject,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
         _content_type: &str,
@@ -1069,6 +1094,7 @@ impl PrimitiveObject {
     fn jwt_verity(
         object: &mut PrimitiveObject,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
         _content_type: &str,
@@ -1155,6 +1181,7 @@ impl PrimitiveObject {
     fn create_hmac(
         object: &mut PrimitiveObject,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
         _content_type: &str,
@@ -1246,6 +1273,7 @@ impl PrimitiveObject {
     fn create_hash(
         object: &mut PrimitiveObject,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
         _content_type: &str,
@@ -1315,6 +1343,7 @@ impl PrimitiveObject {
     fn digest(
         object: &mut PrimitiveObject,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
         _content_type: &str,
@@ -1371,6 +1400,7 @@ impl PrimitiveObject {
     fn base64_encode(
         object: &mut PrimitiveObject,
         _args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
         _content_type: &str,
@@ -1395,6 +1425,7 @@ impl PrimitiveObject {
     fn base64_decode(
         object: &mut PrimitiveObject,
         _args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
         _content_type: &str,
@@ -1429,6 +1460,7 @@ impl PrimitiveObject {
     fn hex_encode(
         object: &mut PrimitiveObject,
         _args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
         _content_type: &str,
@@ -1453,6 +1485,7 @@ impl PrimitiveObject {
     fn hex_decode(
         object: &mut PrimitiveObject,
         _args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
         _content_type: &str,
@@ -1487,6 +1520,7 @@ impl PrimitiveObject {
     fn get_type(
         _object: &mut PrimitiveObject,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
         content_type: &str,
@@ -1506,6 +1540,7 @@ impl PrimitiveObject {
     fn get_content(
         object: &mut PrimitiveObject,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
         content_type: &str,
@@ -1522,6 +1557,7 @@ impl PrimitiveObject {
         Ok(Literal {
             content_type: content_type.to_owned(),
             primitive: Box::new(object.clone()),
+            additional_info: None,
             interval,
         })
     }
@@ -1529,6 +1565,7 @@ impl PrimitiveObject {
     fn is_email(
         object: &mut PrimitiveObject,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
         _content_type: &str,
@@ -1560,6 +1597,7 @@ impl PrimitiveObject {
     fn match_args(
         object: &mut PrimitiveObject,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
         _content_type: &str,
@@ -1589,6 +1627,7 @@ impl PrimitiveObject {
     fn match_array(
         object: &mut PrimitiveObject,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
         _content_type: &str,
@@ -1628,6 +1667,7 @@ impl PrimitiveObject {
     fn is_number(
         _object: &mut PrimitiveObject,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
         _content_type: &str,
@@ -1647,6 +1687,7 @@ impl PrimitiveObject {
     fn is_int(
         _object: &mut PrimitiveObject,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
         _content_type: &str,
@@ -1666,6 +1707,7 @@ impl PrimitiveObject {
     fn is_float(
         _object: &mut PrimitiveObject,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
         _content_type: &str,
@@ -1685,6 +1727,7 @@ impl PrimitiveObject {
     fn type_of(
         _object: &mut PrimitiveObject,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
         _content_type: &str,
@@ -1701,9 +1744,37 @@ impl PrimitiveObject {
         Ok(PrimitiveString::get_literal("object", interval))
     }
 
+    fn get_info(
+        _object: &mut PrimitiveObject,
+        args: &HashMap<String, Literal>,
+        additional_info: &Option<HashMap<String, Literal>>,
+        data: &mut Data,
+        interval: Interval,
+        _content_type: &str,
+    ) -> Result<Literal, ErrorInfo> {
+        literal::get_info(args, additional_info, interval, data)
+    }
+
+    fn is_error(
+        _object: &mut PrimitiveObject,
+        _args: &HashMap<String, Literal>,
+        additional_info: &Option<HashMap<String, Literal>>,
+        _data: &mut Data,
+        interval: Interval,
+        _content_type: &str,
+    ) -> Result<Literal, ErrorInfo> {
+        match additional_info {
+            Some(map) if map.contains_key("error") => {
+                Ok(PrimitiveBoolean::get_literal(true, interval))
+            }
+            _ => Ok(PrimitiveBoolean::get_literal(false, interval))
+        }
+    }
+
     fn to_string(
         object: &mut PrimitiveObject,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
         _content_type: &str,
@@ -1723,6 +1794,7 @@ impl PrimitiveObject {
     fn contains(
         object: &mut PrimitiveObject,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
         _content_type: &str,
@@ -1761,6 +1833,7 @@ impl PrimitiveObject {
     fn is_empty(
         object: &mut PrimitiveObject,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
         _content_type: &str,
@@ -1782,6 +1855,7 @@ impl PrimitiveObject {
     fn length(
         object: &mut PrimitiveObject,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
         _content_type: &str,
@@ -1803,6 +1877,7 @@ impl PrimitiveObject {
     fn keys(
         object: &mut PrimitiveObject,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
         _content_type: &str,
@@ -1828,6 +1903,7 @@ impl PrimitiveObject {
     fn values(
         object: &mut PrimitiveObject,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
         _content_type: &str,
@@ -1853,6 +1929,7 @@ impl PrimitiveObject {
     fn get_generics(
         object: &mut PrimitiveObject,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
         _content_type: &str,
@@ -1894,6 +1971,7 @@ impl PrimitiveObject {
     fn clear_values(
         object: &mut PrimitiveObject,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
         _content_type: &str,
@@ -1925,6 +2003,7 @@ impl PrimitiveObject {
     fn insert(
         object: &mut PrimitiveObject,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
         _content_type: &str,
@@ -1973,6 +2052,7 @@ impl PrimitiveObject {
     fn remove(
         object: &mut PrimitiveObject,
         args: &HashMap<String, Literal>,
+        _additional_info: &Option<HashMap<String, Literal>>,
         data: &mut Data,
         interval: Interval,
         _content_type: &str,
@@ -2055,8 +2135,24 @@ impl PrimitiveObject {
         Literal {
             content_type: "object".to_owned(),
             primitive,
+            additional_info: None,
             interval,
         }
+    }
+
+    pub fn obj_literal_to_json(map: &HashMap<String, Literal>) -> serde_json::Value {
+        let mut object: serde_json::map::Map<String, serde_json::Value> =
+            serde_json::map::Map::new();
+
+        for (key, literal) in map.iter() {
+            let content_type = &literal.content_type;
+            object.insert(
+                key.to_owned(),
+                literal.primitive.format_mem(content_type, false),
+            );
+        }
+
+        serde_json::Value::Object(object)
     }
 }
 
@@ -2167,15 +2263,7 @@ impl Primitive for PrimitiveObject {
 
         match (content_type, first) {
             (content_type, false) if content_type == "object" => {
-                for (key, literal) in self.value.iter() {
-                    let content_type = &literal.content_type;
-                    object.insert(
-                        key.to_owned(),
-                        literal.primitive.format_mem(content_type, false),
-                    );
-                }
-
-                serde_json::Value::Object(object)
+                PrimitiveObject::obj_literal_to_json(&self.value)
             }
             (content_type, _) => {
                 let mut map: serde_json::Map<String, serde_json::Value> = serde_json::Map::new();
@@ -2222,6 +2310,7 @@ impl Primitive for PrimitiveObject {
         &mut self,
         name: &str,
         args: &HashMap<String, Literal>,
+        additional_info: &Option<HashMap<String, Literal>>,
         interval: Interval,
         content_type: &ContentType,
         data: &mut Data,
@@ -2258,7 +2347,7 @@ impl Primitive for PrimitiveObject {
 
         for function in vector.iter() {
             if let Some((f, right)) = function.get(name) {
-                let result = f(self, args, data, interval, &content_type)?;
+                let result = f(self, args, additional_info, data, interval, &content_type)?;
 
                 return Ok((result, *right));
             }
@@ -2271,6 +2360,7 @@ impl Primitive for PrimitiveObject {
                     return res.primitive.do_exec(
                         name,
                         args,
+                        additional_info,
                         interval,
                         &ContentType::Primitive,
                         data,

--- a/csml_interpreter/src/interpreter/ast_interpreter/actions.rs
+++ b/csml_interpreter/src/interpreter/ast_interpreter/actions.rs
@@ -138,6 +138,7 @@ pub fn match_actions(
                             new_value = Literal {
                                 content_type: new_value.content_type,
                                 interval: new_value.interval,
+                                additional_info: None,
                                 primitive
                             };
                         }
@@ -154,6 +155,7 @@ pub fn match_actions(
                             new_value = Literal {
                                 content_type: new_value.content_type,
                                 interval: new_value.interval,
+                                additional_info: None,
                                 primitive
                             };
                         }

--- a/csml_interpreter/src/interpreter/variable_handler.rs
+++ b/csml_interpreter/src/interpreter/variable_handler.rs
@@ -113,6 +113,7 @@ fn loop_path(
                     lit.primitive.exec(
                         "insert",
                         &args,
+                        &lit.additional_info,
                         interval.to_owned(),
                         content_type,
                         &mut false,
@@ -164,6 +165,7 @@ fn loop_path(
                 let mut return_lit = match lit.primitive.exec(
                     name,
                     args,
+                    &lit.additional_info,
                     *interval,
                     content_type,
                     &mut tmp_update_var,

--- a/csml_interpreter/src/interpreter/variable_handler/operations.rs
+++ b/csml_interpreter/src/interpreter/variable_handler/operations.rs
@@ -55,6 +55,7 @@ pub fn evaluate_infix(
                 Ok(primitive) => Ok(Literal {
                     content_type: primitive.get_type().to_string(),
                     primitive,
+                    additional_info: None,
                     interval: lhs.interval,
                 }),
                 Err(err) => Err(gen_error_info(Position::new(lhs.interval, flow_name), err)),
@@ -67,6 +68,7 @@ pub fn evaluate_infix(
                 Ok(primitive) => Ok(Literal {
                     content_type: primitive.get_type().to_string(),
                     primitive,
+                    additional_info: None,
                     interval: lhs.interval,
                 }),
                 Err(err) => Err(gen_error_info(Position::new(lhs.interval, flow_name), err)),
@@ -79,6 +81,7 @@ pub fn evaluate_infix(
                 Ok(primitive) => Ok(Literal {
                     content_type: primitive.get_type().to_string(),
                     primitive,
+                    additional_info: None,
                     interval: lhs.interval,
                 }),
                 Err(err) => Err(gen_error_info(Position::new(lhs.interval, flow_name), err)),
@@ -92,6 +95,7 @@ pub fn evaluate_infix(
                 Ok(primitive) => Ok(Literal {
                     content_type: primitive.get_type().to_string(),
                     primitive,
+                    additional_info: None,
                     interval: lhs.interval,
                 }),
                 Err(err) => Err(gen_error_info(Position::new(lhs.interval, flow_name), err)),
@@ -104,6 +108,7 @@ pub fn evaluate_infix(
                 Ok(primitive) => Ok(Literal {
                     content_type: primitive.get_type().to_string(),
                     primitive,
+                    additional_info: None,
                     interval: lhs.interval,
                 }),
                 Err(err) => Err(gen_error_info(Position::new(lhs.interval, flow_name), err)),

--- a/csml_interpreter/src/lib.rs
+++ b/csml_interpreter/src/lib.rs
@@ -14,6 +14,7 @@ use parser::parse_flow;
 use data::ast::{Expr, Flow, InstructionScope, Interval};
 use data::context::get_hashmap_from_mem;
 use data::error_info::ErrorInfo;
+use data::literal::create_error_info;
 use data::event::Event;
 use data::message_data::MessageData;
 use data::msg::MSG;
@@ -266,13 +267,17 @@ pub fn interpret(
         let ast = match flows.get(&flow) {
             Some(result) => result.to_owned(),
             None => {
+                let error_message = format!("flow '{}' does not exist in this bot", flow);
+                let error_info = create_error_info(&error_message, Interval::default());
+
                 return MessageData::error_to_message(
                     Err(ErrorInfo {
                         position: Position {
                             flow: flow.clone(),
                             interval: Interval::default(),
                         },
-                        message: format!("flow '{}' does not exist in this bot", flow),
+                        message: error_message,
+                        additional_info: Some(error_info)
                     }),
                     &sender,
                 );

--- a/csml_interpreter/src/parser/parse_literal.rs
+++ b/csml_interpreter/src/parser/parse_literal.rs
@@ -100,6 +100,7 @@ where
         literal: Literal {
             content_type: "boolean".to_owned(),
             primitive,
+            additional_info: None,
             interval,
         },
         in_in_substring: false,


### PR DESCRIPTION
add extra info into primitives
 -All primitives now have new  get_info() and is_error() methods
 -Improve  HTTP error handling with extra info  error results now have headers, body an status as  additional info


